### PR TITLE
Rakefile Fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,8 @@ end
 
 task :deb => [:chdir_pkg, :turnstile_source] do
   command = [
+    'bundle',
+    'exec',
     'fpm',
     '--deb-no-default-config-files',
     "--depends \"nodejs >= #{target_version}\"",


### PR DESCRIPTION
This PR prefixes the fpm command with `bundle exec` to resolve issue with tasks being run using an old version of bundler.
