### PR TITLE
Separate cookbook and build gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'fpm', '~> 1.6'
-gem 'builderator', '~> 1.0'
 gem 'octokit', '~> 4.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -49,12 +49,12 @@ def install_dir
   ::File.join('pkg', 'opt', name)
 end
 
-def base_dir
-  @base_dir ||= File.dirname(File.expand_path(__FILE__))
-end
-
 def pkg_dir
   ::File.join(base_dir, 'pkg')
+end
+
+def base_dir
+  @base_dir ||= File.dirname(File.expand_path(__FILE__))
 end
 
 def github_client
@@ -91,7 +91,6 @@ task :turnstile_source => [:install] do
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
 end
-
 
 task :chdir_pkg => [:package_dirs] do
   cd pkg_dir


### PR DESCRIPTION
This PR defines a `:cookbook` group so we can use the `--without` flag when we want to `bundle install` and not have to wait forever for `dep-selector-libgecode` to install.
