### PR TITLE
Make Rakefile great again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'fpm', '~> 1.6'
-gem 'builderator', '~> 1.0'
 gem 'octokit', '~> 4.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'rake', '~> 10.5'
+gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.6'
 gem 'octokit', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     plist (3.2.0)
     proxifier (1.0.3)
     rack (1.6.4)
+    rake (10.5.0)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable
@@ -259,9 +260,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 2.2)
   builderator (~> 1.0)
   fpm (~> 1.6)
   octokit (~> 4.0)
+  rake (~> 10.5)
 
 BUNDLED WITH
    1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -49,12 +49,12 @@ def install_dir
   ::File.join('pkg', 'opt', name)
 end
 
-def base_dir
-  @base_dir ||= File.dirname(File.expand_path(__FILE__))
-end
-
 def pkg_dir
   ::File.join(base_dir, 'pkg')
+end
+
+def base_dir
+  @base_dir ||= File.dirname(File.expand_path(__FILE__))
 end
 
 def github_client
@@ -91,7 +91,6 @@ task :turnstile_source => [:install] do
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
 end
-
 
 task :chdir_pkg => [:package_dirs] do
   cd pkg_dir

--- a/Rakefile
+++ b/Rakefile
@@ -119,7 +119,8 @@ task :deb => [:chdir_pkg, :source] do
   sh command
 end
 
-task :upload_packages => [:deb] do
+task :upload_packages do
+  cd pkg_dir
   mkdir 'copy_to_s3'
   deb = Dir["#{name}_#{version}_*.deb"].first
   cp deb, 'copy_to_s3/'
@@ -131,7 +132,7 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release => [:package] do
+task :release do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
@@ -172,3 +173,4 @@ CLEAN.include '**/.DS_Store'
 CLEAN.include 'node_modules/'
 
 task :default => [:clean, :package, :release]
+task :upload => [:clean, :package, :upload_packages]

--- a/Rakefile
+++ b/Rakefile
@@ -131,12 +131,12 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release do
+task :release => [:package] do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
-  puts
   puts 'Make sure you add release notes!'
+
   cp ::File.join(base_dir, "#{name}-#{version}.tgz"), pkg_dir
 
   begin
@@ -161,6 +161,9 @@ task :release do
   compare_url = "#{github_repo.url}/compare/#{latest_release.name}...#{release.name}"
   puts "You can find a diff between this release and the previous one here: #{compare_url}"
 end
+
+desc "Package #{name}"
+task :package => [:install, :shrinkwrap, :pack, :deb]
 
 CLEAN.include 'npm-shrinkwrap.json'
 CLEAN.include "#{name}-*.tgz"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'json'
 require 'fileutils'
 require 'mkmf'
+require 'aws-sdk'
+require 'logger'
 require 'rake/clean'
 require 'octokit'
 
@@ -8,6 +10,7 @@ include FileUtils
 
 CLIENT_ID = ENV['GITHUB_CLIENT_ID']
 CLIENT_TOKEN = ENV['GITHUB_CLIENT_TOKEN']
+ARTIFACT_BUCKET = ENV['ARTIFACT_BUCKET']
 
 def package_json
   @package_json ||= JSON.parse(File.read('package.json'))
@@ -116,8 +119,16 @@ task :deb => [:chdir_pkg, :turnstile_source] do
   sh command
 end
 
-desc "Package #{name}"
-task :package => [:install, :shrinkwrap, :pack, :deb]
+task :upload_packages => [:deb] do
+  mkdir 'copy_to_s3'
+  deb = Dir["#{name}_#{version}_*.deb"].first
+  cp deb, 'copy_to_s3/'
+  s3 = Aws::S3::Resource.new(region: 'us-east-1', logger: Logger.new(STDOUT))
+  Dir["copy_to_s3/**/#{name}*"].each do |package|
+    upload_package = ::File.basename(package)
+    s3.bucket(ARTIFACT_BUCKET).object("#{name}/#{upload_package}").upload_file(package)
+  end
+end
 
 desc "Release #{name} and prepare to create a release on github.com"
 task :release do

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,7 @@ task :package_dirs do
   mkdir_p ::File.join(base_dir, install_dir)
 end
 
-task :turnstile_source => [:install] do
+task :source => [:install] do
   ['bin/', 'lib/', 'node_modules/', 'LICENSE', 'package.json'].each do |src|
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
@@ -99,7 +99,7 @@ task :chdir_pkg => [:package_dirs] do
   cd pkg_dir
 end
 
-task :deb => [:chdir_pkg, :turnstile_source] do
+task :deb => [:chdir_pkg, :source] do
   command = [
     'bundle',
     'exec',


### PR DESCRIPTION
This PR makes Rakefile tasks more consistent across the Spectre services. It was branched off of [gem-groups](https://github.com/rapid7/turnstile/tree/gem-groups) but while it could be merged now, we should wait until #7 is merged just to make sure the intent of both pull requests is respected.
