### PR TITLE
Adds the debugging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,14 @@
 {
-  "plugins": [
-    "rapid7"
-  ],
-  "extends": "rapid7",
   "globals": {
     "Config": true,
     "Log": true
   },
-  "env": {
-    "node": true
+  "plugins": ["import"],
+  "extends": [
+    "rapid7/base",
+    "rapid7/rules/node"
+  ],
+  "rules": {
+    "arrow-body-style": 0
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 sudo: false
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y uuid-dev
+addons:
+  apt:
+    packages:
+      - build-essential
+      - uuid-dev
 script:
   - npm test
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 sudo: false
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y uuid-dev
 script:
   - npm test
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+# According to https://docs.travis-ci.com/user/ci-environment,
+# `sudo: required` must be set to use `dist: trusty`
 dist: trusty
+sudo: required
+
 language: node_js
-sudo: false
 addons:
   apt:
     packages:

--- a/bin/server
+++ b/bin/server
@@ -7,6 +7,11 @@ require('../lib/log');
 const app = require('../lib/control/layer').create();
 const server = require('http').createServer(app);
 
+// Only attach the correlation ID middleware if it's enabled
+if (Config.get('correlation:enable')) {
+  app.use(require('../lib/control/correlation').create(Config.get('correlation')));
+}
+
 app.use(require('../lib/provider/local').authn(Config.get('local')));
 app.use(require('../lib/control/forward').create(Config.get('service')));
 

--- a/bin/turnt
+++ b/bin/turnt
@@ -59,6 +59,13 @@ Config.defaults({
     timestamp: false,
     colorize: true
   }
+  // log: {
+  //   level: 'info',
+  //   colorize: false,
+  //   timestamp: true,
+  //   json: true,
+  //   stringify: true
+  // }
 });
 
 require('../lib/log');

--- a/bin/turnt
+++ b/bin/turnt
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 'use strict';
 
 const Crypto = require('crypto');
@@ -10,8 +9,7 @@ const Path = require('path');
 const Signature = require('../lib/signature');
 const URL = require('url');
 
-require('../lib/config');
-require('../lib/log');
+global.Config = require('nconf');
 
 Config.argv({
   config: {
@@ -20,21 +18,27 @@ Config.argv({
   },
   method: {
     alias: 'X',
-    default: 'GET',
-    describe: 'HTTP request method'
+    describe: 'HTTP request method',
+    default: 'GET'
   },
   payload: {
     alias: 'd',
-    describe: 'HTTP request payload'
+    describe: 'HTTP request payload',
+    default: false
   },
   digest: {
-    default: 'sha256',
-    describe: 'Digest signing scheme'
+    describe: 'Digest signing scheme',
+    default: 'sha256'
   },
   header: {
     alias: 'H',
     array: true,
     describe: 'HTTP request headers'
+  },
+  output: {
+    alias: 'o',
+    describe: 'Write output to a file',
+    default: false
   },
 
   identity: {
@@ -46,125 +50,198 @@ Config.argv({
     alias: 'p',
     demand: true,
     describe: 'Secret key for the request'
-  },
-
-  verbose: {
-    alias: 'v',
-    describe: 'Print verbose status information'
   }
 });
 
+Config.defaults({
+  log: {
+    json: false,
+    timestamp: false,
+    colorize: true
+  }
+});
+
+require('../lib/log');
+
+/**
+ * Load request data from STDIN, a file, or from the argument value
+ * @param  {String} payload The value of the `-d/--payload` flag. A `-` indicates
+ *                          that data should be read from STDIN, while a leading `@`
+ *                          indicates that the rest of the value is the path to a
+ *                          file that should be read.
+ * @return {Promise}
+ */
+function read(payload) {
+  return new Promise(function(resolve, reject) {
+    if (typeof payload !== 'string') {
+      return resolve(false);
+    }
+
+    switch (payload[0]) {
+    case '-': // Read from STDIN
+      const data = [];
+
+      process.stdin.on('data', (chunk) => data.push(chunk));
+      process.stdin.on('end', () => resolve(Buffer.concat(data)));
+      break;
+
+    case '@': // Read from a file
+      FS.readFile(Path.resolve(__dirname, payload.slice(1)), (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(data);
+      });
+      break;
+
+    default: // Convert argument value to a buffer
+      resolve(Buffer.from(payload, 'utf8'));
+    }
+  });
+}
+
+/**
+ * Generate a digest signature for the request's headers
+ *
+ * @param  {String} algorithm Hash algorithm
+ * @param  {Buffer} payload   Request body
+ * @return {String}           Base64-encoded hash signature
+ */
+function digest(algorithm, payload) {
+  const hash = Crypto.createHash(algorithm);
+
+  return new Promise(function(resolve) {
+    if (payload) {
+      hash.update(payload);
+    }
+
+    resolve(hash.digest('base64'));
+  });
+}
+
+/**
+ * Make an HTTP[S] request
+ *
+ * @param  {Object} protocol An HTTP provider for the request
+ * @param  {Object} params Request parameters. @see {@link https://nodejs.org/
+ *                         dist/latest-v4.x/docs/api/http.html#http_http_request_options_callback}
+ * @return {Promise}
+ */
+function request(protocol, params) {
+  const algorithm = Config.get('digest');
+
+  return read(Config.get('payload'))
+    .then((payload) => {
+      return (params.payload = payload);
+    })
+    .then((payload) => digest(algorithm, payload))
+    .then((signature) => {
+      params.headers.digest = `${algorithm}=${signature}`;
+    })
+    .then(() => {
+      const signature = new Signature('sha256', params);
+
+      signature.sign(Config.get('secret'));
+      Log.debug(`Request: identity ${params.identity}`);
+      Log.debug(`Request: signature ${signature.signature}`);
+
+      const authorization = Buffer(`${params.identity}:${signature.signature}`, 'utf8').toString('base64');
+
+      params.headers.authorization = `Rapid7-HMAC-V1-SHA256 ${authorization}`;
+      Log.debug(`Request: authorization ${params.headers.authorization}`);
+    })
+    .then(() => new Promise(function(resolve, reject) {
+      const req = protocol.request(params);
+
+      req.on('abort', () => reject());
+      req.on('aborted', () => reject());
+      req.on('error', (err) => reject(err));
+      req.on('response', (res) => {
+        const chunks = [];
+
+        Log.debug(`Response: HTTP/1.1 ${res.statusCode} ${res.statusMessage}`);
+        Object.keys(res.headers).forEach((header) => {
+          Log.debug(`Response: header ${header}: ${res.headers[header]}`);
+        });
+
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const payload = Buffer.concat(chunks);
+
+          res.payload = payload.toString('utf8');
+          Log.debug(`Response: received ${payload.length} bytes`);
+
+          resolve(res);
+        });
+      });
+
+      req.setHeader('Content-Length',
+        params.payload ? params.payload.length : 0);
+
+      Log.debug(`Request: ${params.method} ${params.path} HTTP/1.1`);
+      Object.keys(params.headers).forEach((header) => {
+        Log.debug(`Request: header ${header}: ${params.headers[header]}`);
+      });
+
+      if (params.payload) {
+        Log.debug(`Request: sending ${params.payload.length} bytes`);
+        req.write(params.payload);
+      }
+
+      req.end();
+    }));
+}
+
 const date = new Date();
 const url = Config.get('_')[0];
-const request = URL.parse(url);
+const params = URL.parse(url);
 
-request.method = Config.get('method');
-request.headers = {
+params.method = Config.get('method');
+params.headers = {
   date: date.toString(),
-  host: request.host,
+  host: params.host,
   'user-agent': `node-${process.version}/turnstile-tester`
 };
 
 // Select HTTP[S] provider
-const Protocol = request.protocol === 'https:' ? HTTPS : HTTP;
+const protocol = params.protocol === 'https:' ? HTTPS : HTTP;
 
 // Remove extra/overriding request parameters
-delete request.protocol;
-delete request.auth;
-delete request.host;
-delete request.pathname;
-delete request.query;
-delete request.search;
-delete request.hash;
-delete request.href;
+delete params.protocol;
+delete params.auth;
+delete params.host;
+delete params.pathname;
+delete params.query;
+delete params.search;
+delete params.hash;
+delete params.href;
 
 // Round date to the nearest seconds for signing
-request.date = new Date(date);
-request.date.setMilliseconds(0);
+params.date = new Date(date);
+params.date.setMilliseconds(0);
 
-request.identity = Config.get('identity');
+params.identity = Config.get('identity');
 
-// Read data for request payload
-let data = Config.get('payload');
-const hash = Crypto.createHash(Config.get('digest'));
+request(protocol, params)
+  .then((res) => new Promise(function(resolve, reject) {
+    const output = Config.get('output');
 
-switch (data[0]) {
-case '-':
-  // Read from STDIN
-  data = '';
+    if (!output) {
+      process.stdout.write(res.payload);
 
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', (d) => {
-    data += d;
-  });
-  process.stdin.on('end', () => resumeRequest());
-  break;
-
-case '@':
-  // Read from a file
-  data = FS.readFileSync(Path.resolve(__dirname, data.slice(1)));
-  resumeRequest();
-  break;
-
-default:
-  resumeRequest();
-}
-
-function resumeRequest() {
-  if (data) {
-    hash.update(data, 'utf8');
-  }
-  request.headers.digest = `${Config.get('digest')}=${hash.digest('hex')}`;
-
-  const signature = new Signature('sha256', request);
-  signature.sign(Config.get('secret'));
-
-  Log.debug(`Request Identity: ${request.identity}`);
-  Log.debug(`Request Signature: ${signature.signature}`);
-
-  const authorization = Buffer(`${request.identity}:${signature.signature}`, 'utf8').toString('base64');
-  request.headers.authorization = `Rapid7-HMAC-V1-SHA256 ${authorization}`;
-
-  const req = Protocol.request(request);
-
-  if (Config.get('verbose')) {
-    Log.info(`> ${request.method} ${request.path} HTTP/1.1`);
-    Object.keys(request.headers).forEach((header) => {
-      Log.info(`> ${header}: ${request.headers[header]}`);
-    });
-
-    if (data) {
-      Log.info(`> Sending ${Buffer.byteLength(data)} bytes`);
+      return resolve();
     }
 
-    Log.info('>');
-  }
+    if (res.payload.length > 0) {
+      FS.writeFile(output, res.payload, (err) => {
+        if (err) {
+          return reject(err);
+        }
 
-  req.on('response', function(response) {
-    const chunks = [];
-
-    if (Config.get('verbose')) {
-      Log.info(`< HTTP/1.1 ${response.statusCode} ${response.statusMessage}`);
-      Object.keys(response.headers).forEach((header) => {
-        Log.info(`< ${header}: ${response.headers[header]}`);
+        Log.info(`Wrote ${res.payload.length} bytes to ${output}`);
+        resolve();
       });
     }
-
-    response.on('data', (d) => chunks.push(d));
-    response.on('end', () => {
-      const rdata = Buffer.concat(chunks);
-
-      if (Config.get('verbose')) {
-        Log.info(`< Received ${rdata.length} bytes`);
-        Log.info('<');
-      }
-
-      process.stdout.write(rdata);
-    });
-  });
-
-  if (data) {
-    req.write(data, 'utf8');
-  }
-  req.end();
-}
+  }))
+  .catch((err) => Log.error(err));

--- a/bin/turnt
+++ b/bin/turnt
@@ -59,13 +59,6 @@ Config.defaults({
     timestamp: false,
     colorize: true
   }
-  // log: {
-  //   level: 'info',
-  //   colorize: false,
-  //   timestamp: true,
-  //   json: true,
-  //   stringify: true
-  // }
 });
 
 require('../lib/log');

--- a/bin/turnt
+++ b/bin/turnt
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const Crypto = require('crypto');
+const FS = require('fs');
+const HTTP = require('http');
+const HTTPS = require('https');
+const Path = require('path');
+const Signature = require('../lib/signature');
+const URL = require('url');
+
+require('../lib/config');
+require('../lib/log');
+
+Config.argv({
+  config: {
+    alias: 'c',
+    describe: 'Path to local turnstile configuration'
+  },
+  method: {
+    alias: 'X',
+    default: 'GET',
+    describe: 'HTTP request method'
+  },
+  payload: {
+    alias: 'd',
+    describe: 'HTTP request payload'
+  },
+  digest: {
+    default: 'sha256',
+    describe: 'Digest signing scheme'
+  },
+  header: {
+    alias: 'H',
+    array: true,
+    describe: 'HTTP request headers'
+  },
+
+  identity: {
+    alias: 'u',
+    demand: true,
+    describe: 'Identity key for the request'
+  },
+  secret: {
+    alias: 'p',
+    demand: true,
+    describe: 'Secret key for the request'
+  },
+
+  verbose: {
+    alias: 'v',
+    describe: 'Print verbose status information'
+  }
+});
+
+const date = new Date();
+const url = Config.get('_')[0];
+const request = URL.parse(url);
+
+request.method = Config.get('method');
+request.headers = {
+  date: date.toString(),
+  host: request.host,
+  'user-agent': `node-${process.version}/turnstile-tester`
+};
+
+// Select HTTP[S] provider
+const Protocol = request.protocol === 'https:' ? HTTPS : HTTP;
+
+// Remove extra/overriding request parameters
+delete request.protocol;
+delete request.auth;
+delete request.host;
+delete request.pathname;
+delete request.query;
+delete request.search;
+delete request.hash;
+delete request.href;
+
+// Round date to the nearest seconds for signing
+request.date = new Date(date);
+request.date.setMilliseconds(0);
+
+request.identity = Config.get('identity');
+
+// Read data for request payload
+let data = Config.get('payload');
+const hash = Crypto.createHash(Config.get('digest'));
+
+switch (data[0]) {
+case '-':
+  // Read from STDIN
+  data = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (d) => {
+    data += d;
+  });
+  process.stdin.on('end', () => resumeRequest());
+  break;
+
+case '@':
+  // Read from a file
+  data = FS.readFileSync(Path.resolve(__dirname, data.slice(1)));
+  resumeRequest();
+  break;
+
+default:
+  resumeRequest();
+}
+
+function resumeRequest() {
+  if (data) {
+    hash.update(data, 'utf8');
+  }
+  request.headers.digest = `${Config.get('digest')}=${hash.digest('hex')}`;
+
+  const signature = new Signature('sha256', request);
+  signature.sign(Config.get('secret'));
+
+  Log.debug(`Request Identity: ${request.identity}`);
+  Log.debug(`Request Signature: ${signature.signature}`);
+
+  const authorization = Buffer(`${request.identity}:${signature.signature}`, 'utf8').toString('base64');
+  request.headers.authorization = `Rapid7-HMAC-V1-SHA256 ${authorization}`;
+
+  const req = Protocol.request(request);
+
+  if (Config.get('verbose')) {
+    Log.info(`> ${request.method} ${request.path} HTTP/1.1`);
+    Object.keys(request.headers).forEach((header) => {
+      Log.info(`> ${header}: ${request.headers[header]}`);
+    });
+
+    if (data) {
+      Log.info(`> Sending ${Buffer.byteLength(data)} bytes`);
+    }
+
+    Log.info('>');
+  }
+
+  req.on('response', function(response) {
+    const chunks = [];
+
+    if (Config.get('verbose')) {
+      Log.info(`< HTTP/1.1 ${response.statusCode} ${response.statusMessage}`);
+      Object.keys(response.headers).forEach((header) => {
+        Log.info(`< ${header}: ${response.headers[header]}`);
+      });
+    }
+
+    response.on('data', (d) => chunks.push(d));
+    response.on('end', () => {
+      const rdata = Buffer.concat(chunks);
+
+      if (Config.get('verbose')) {
+        Log.info(`< Received ${rdata.length} bytes`);
+        Log.info('<');
+      }
+
+      process.stdout.write(rdata);
+    });
+  });
+
+  if (data) {
+    req.write(data, 'utf8');
+  }
+  req.end();
+}

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -17,5 +17,5 @@ default['turnstile']['paths']['configuration'] = '/etc/turnstile/config.json'
 
 default['turnstile']['config'] = Mash.new
 default['turnstile']['version'] = nil
-default['turnstile']['install'] = :github
+default['turnstile']['install'] = :github_release
 default['turnstile']['enable'] = true

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -1,3 +1,12 @@
+#
+# Cookbook Name:: turnstile
+# Attribute:: default
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
 
 default['turnstile']['user'] = 'turnstile'
 default['turnstile']['group'] = 'turnstile'
@@ -8,3 +17,5 @@ default['turnstile']['paths']['configuration'] = '/etc/turnstile/config.json'
 
 default['turnstile']['config'] = Mash.new
 default['turnstile']['version'] = nil
+default['turnstile']['install'] = :github
+default['turnstile']['enable'] = true

--- a/cookbook/recipes/_install_github.rb
+++ b/cookbook/recipes/_install_github.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: turnstile
+# Recipe:: _install_github
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+## Fetch and install turnstile
+remote_file 'turnstile' do
+  source Turnstile::Helpers.github_download('rapid7', 'turnstile', node['turnstile']['version'])
+  path ::File.join(Chef::Config['file_cache_path'], "turnstile-#{node['turnstile']['version']}.deb")
+
+  action :create_if_missing
+  backup false
+end
+
+package 'turnstile' do
+  source resources('remote_file[turnstile]').path
+  provider Chef::Provider::Package::Dpkg
+end

--- a/cookbook/recipes/_install_github_ref.rb
+++ b/cookbook/recipes/_install_github_ref.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: turnstile
+# Recipe:: _install_github_ref
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+## Fetch and install turnstile
+remote_file 'turnstile' do
+  source "https://github.com/rapid7/turnstile/archive/#{node['turnstile']['version']}.tar.gz"
+  path ::File.join(Chef::Config['file_cache_path'], "turnstile-#{node['turnstile']['version']}.tar.gz")
+
+  action :create_if_missing
+  backup false
+
+  notifies :run, 'execute[extract source]', :immediate
+end
+
+## Unpack GitHub tarball
+execute 'extract source' do
+  command ["tar -xzf #{resources('remote_file[turnstile]').path}",
+           '--strip-components=1',
+           "--directory #{node['turnstile']['paths']['directory']}"].join(' ')
+
+  action :nothing
+  notifies :run, 'execute[npm install]', :immediate
+end
+
+## Install module dependencies
+execute 'npm install' do
+  command '/usr/bin/npm install'
+  cwd node['turnstile']['paths']['directory']
+  environment 'HOME' => node['turnstile']['paths']['directory']
+  action :nothing
+end

--- a/cookbook/recipes/_install_github_ref.rb
+++ b/cookbook/recipes/_install_github_ref.rb
@@ -19,13 +19,18 @@ remote_file 'turnstile' do
   notifies :run, 'execute[extract source]', :immediate
 end
 
+directory node['turnstile']['paths']['directory']
+
 ## Unpack GitHub tarball
 execute 'extract source' do
   command ["tar -xzf #{resources('remote_file[turnstile]').path}",
            '--strip-components=1',
            "--directory #{node['turnstile']['paths']['directory']}"].join(' ')
 
-  action :nothing
+  action ::File.exist?(
+    ::File.join(node['turnstile']['paths']['directory'], 'package.json')
+  ) ? :nothing : :run
+
   notifies :run, 'execute[npm install]', :immediate
 end
 

--- a/cookbook/recipes/_install_github_ref.rb
+++ b/cookbook/recipes/_install_github_ref.rb
@@ -7,6 +7,7 @@
 # Distributed under terms of the MIT License. All rights not explicitly granted
 # in the MIT license are reserved. See the included LICENSE file for more details.
 #
+directory node['turnstile']['paths']['directory']
 
 ## Fetch and install turnstile
 remote_file 'turnstile' do
@@ -18,8 +19,6 @@ remote_file 'turnstile' do
 
   notifies :run, 'execute[extract source]', :immediate
 end
-
-directory node['turnstile']['paths']['directory']
 
 ## Unpack GitHub tarball
 execute 'extract source' do

--- a/cookbook/recipes/_install_github_release.rb
+++ b/cookbook/recipes/_install_github_release.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: turnstile
-# Recipe:: _install_github
+# Recipe:: _install_github_release
 #
 # Copyright (C) 2016 Rapid7 LLC.
 #

--- a/cookbook/recipes/_install_local.rb
+++ b/cookbook/recipes/_install_local.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: turnstile
+# Recipe:: _install_local
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+Chef::Application.fatal!(
+  "Mount the Turnstile application at #{node['turnstile']['paths']['directory']}"
+) unless ::Dir.exist?(node['turnstile']['paths']['directory'])
+
+execute 'npm install' do
+  command '/usr/bin/npm install'
+  cwd node['turnstile']['paths']['directory']
+  environment 'HOME' => node['turnstile']['paths']['directory']
+end

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -42,7 +42,8 @@ user node['turnstile']['user'] do
 end
 
 case node['turnstile']['install'].to_sym
-when :github then include_recipe "#{cookbook_name}::_install_github"
+when :github_release then include_recipe "#{cookbook_name}::_install_github_release"
+when :github_ref then include_recipe "#{cookbook_name}::_install_github_ref"
 when :local then include_recipe "#{cookbook_name}::_install_local"
 else Chef::Application.fatal!("Unhanded Turnstile installation method #{node['turnstile']['install']}")
 end

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -25,6 +25,7 @@ package 'nodejs'
 #######################
 
 ## node-libuuid support
+package 'build-essential'
 package 'uuid-dev'
 
 node.default['turnstile']['version'] = cookbook_version

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -24,6 +24,9 @@ end
 package 'nodejs'
 #######################
 
+## node-libuuid support
+package 'uuid-dev'
+
 node.default['turnstile']['version'] = cookbook_version
 
 group node['turnstile']['group'] do
@@ -38,33 +41,14 @@ user node['turnstile']['user'] do
   home node['turnstile']['paths']['directory']
 end
 
-directory node['turnstile']['paths']['directory'] do
-  owner node['turnstile']['user']
-  group node['turnstile']['group']
-  mode '0755'
-
-  recursive true
-end
-
-## Fetch and install turnstile
-remote_file 'turnstile' do
-  source Turnstile::Helpers.github_download('rapid7', 'turnstile', node['turnstile']['version'])
-  path ::File.join(Chef::Config['file_cache_path'], "turnstile-#{node['turnstile']['version']}.deb")
-
-  action :create_if_missing
-  backup false
-end
-
-package 'turnstile' do
-  source resources('remote_file[turnstile]').path
-  provider Chef::Provider::Package::Dpkg
+case node['turnstile']['install'].to_sym
+when :github then include_recipe "#{cookbook_name}::_install_github"
+when :local then include_recipe "#{cookbook_name}::_install_local"
+else Chef::Application.fatal!("Unhanded Turnstile installation method #{node['turnstile']['install']}")
 end
 
 ## Upstart Service
 template '/etc/init/turnstile.conf' do
-  owner node['turnstile']['user']
-  group node['turnstile']['group']
-
   source 'upstart.conf.erb'
   variables(
     :description => 'turnstile configuration service',
@@ -74,13 +58,12 @@ template '/etc/init/turnstile.conf' do
       "-c #{node['turnstile']['paths']['configuration']}"
     ]
   )
+
+  notifies :restart, 'service[turnstile]' if node['turnstile']['enable']
 end
 
 directory 'turnstile-configuration-directory' do
   path ::File.dirname(node['turnstile']['paths']['configuration'])
-
-  owner node['turnstile']['user']
-  group node['turnstile']['group']
   mode '0755'
 
   recursive true
@@ -90,15 +73,12 @@ template 'turnstile-configuration' do
   path node['turnstile']['paths']['configuration']
   source 'json.erb'
 
-  owner node['turnstile']['user']
-  group node['turnstile']['group']
+  variables :properties => node['turnstile']['config']
 
-  variables(:properties => node['turnstile']['config'])
+  notifies :restart, 'service[turnstile]' if node['turnstile']['enable']
 end
 
 service 'turnstile' do
-  ## The wrapping cookbook must call `action` on this resource to start/enable
-  action :nothing
-
+  action node['turnstile']['enable'] ? [:start, :enable] : [:stop, :disable]
   provider Chef::Provider::Service::Upstart
 end

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,8 +31,10 @@ Config.defaults({
   },
   log: {
     level: 'info',
-    colorize: true,
-    timestamp: true
+    colorize: false,
+    timestamp: true,
+    json: true,
+    stringify: true
   },
   correlation: {
     enable: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,7 +12,7 @@ const Path = require('path');
  * @global
  * @param {Yargs} args
  */
-const Config = global.Config = require('nconf').env()
+const Config = global.Config = require('nconf')
   .argv({
     config: {
       alias: 'c',
@@ -33,6 +33,10 @@ Config.defaults({
     level: 'info',
     colorize: true,
     timestamp: true
+  },
+  correlation: {
+    enable: true,
+    header: 'X-Request-Identifier'
   },
   local: {
     db: {

--- a/lib/control/correlation.js
+++ b/lib/control/correlation.js
@@ -13,11 +13,19 @@ exports.create = function create(options) {
 
   return function handle(req, res, next) {
     if (!req.headers.hasOwnProperty(header)) {
-      req.headers[header] = UUID.v4();
-      Log.debug(`Setting Correlation-Identifier header ${header}:${req.headers[header]}`);
+      req.identifier = req.headers[header] = UUID.v4();
+      Log.debug(`Setting Correlation-Identifier header ${header}:${req.identifier}`, {
+        identifier: req.identifier
+      });
+
+      return next();
     }
 
     req.identifier = req.headers[header];
+    Log.debug(`Found Correlation-Identifier header ${header}:${req.identifier}`, {
+      identifier: req.identifier
+    });
+
     next();
   };
 };

--- a/lib/control/correlation.js
+++ b/lib/control/correlation.js
@@ -1,0 +1,23 @@
+'use strict';
+const UUID = require('node-libuuid');
+
+exports.create = function create(options) {
+  options = Object.assign({}, options);
+
+  if (!options.hasOwnProperty('header')) {
+    throw ReferenceError('Missing required parameter `header`!');
+  }
+
+  Log.info(`Using Correlation-Identifier ${options.header}`);
+  const header = options.header;
+
+  return function handle(req, res, next) {
+    if (!req.headers.hasOwnProperty(header)) {
+      req.headers[header] = UUID.v4();
+      Log.debug(`Setting Correlation-Identifier header ${header}:${req.headers[header]}`);
+    }
+
+    req.identifier = req.headers[header];
+    next();
+  };
+};

--- a/lib/control/forward.js
+++ b/lib/control/forward.js
@@ -36,7 +36,15 @@ function create(options) {
 
   if (!port) { throw new TypeError('Option `port` must be a number'); }
 
+  Log.info(`Using HTTP forwarder to ${hostname}:${port}`);
+
   return function handle(req, res, next) {
+    Log.debug(`Forwarding request to ${hostname}:${port}${req.url}`, {
+      identifier: req.identifier,
+      method: req.method,
+      path: req.url
+    });
+
     const forward = HTTP.request({
       method: req.method,
       path: req.url,

--- a/lib/control/layer.js
+++ b/lib/control/layer.js
@@ -14,6 +14,9 @@ const Errors = require('../errors');
  * A minimal HTTP router, without routes.
  */
 class Layer {
+  /**
+   * @constructor
+   */
   constructor() {
     this.layers = [];
   }
@@ -36,9 +39,11 @@ class Layer {
   static create() {
     const controller = new Layer();
 
+    /* eslint-disable require-jsdoc */
     function handler(req, res) {
       controller.each(req, res);
     }
+    /* eslint-enable require-jsdoc */
 
     handler.controller = controller;
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -73,6 +73,8 @@ class HTTPError extends Error {
 
     res.write(content);
     res.end();
+
+    Log.debug(err);
   }
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -88,10 +88,8 @@ exports = module.exports = HTTPError;
  * @extends HTTPError
  */
 class RequestError extends HTTPError {
-  constructor(reason) {
-    super(STATUS_CODES.BAD_REQUEST, null, {
-      reason
-    });
+  constructor(reason, metadata) {
+    super(STATUS_CODES.BAD_REQUEST, null, Object.assign({reason}, metadata));
   }
 }
 
@@ -105,10 +103,8 @@ exports.RequestError = RequestError;
  * @extends HTTPError
  */
 class AuthorizationError extends HTTPError {
-  constructor(reason) {
-    super(STATUS_CODES.UNAUTHORIZED, null, {
-      reason
-    });
+  constructor(reason, metadata) {
+    super(STATUS_CODES.UNAUTHORIZED, null, Object.assign({reason}, metadata));
   }
 }
 
@@ -122,10 +118,8 @@ exports.AuthorizationError = AuthorizationError;
  * @extends HTTPError
  */
 class NotFoundError extends HTTPError {
-  constructor(method, path) {
-    super(STATUS_CODES.NOT_FOUND, null, {
-      method, path
-    });
+  constructor(method, path, metadata) {
+    super(STATUS_CODES.NOT_FOUND, null, Object.assign({method, path}, metadata));
   }
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -88,6 +88,11 @@ exports = module.exports = HTTPError;
  * @extends HTTPError
  */
 class RequestError extends HTTPError {
+  /**
+   * @constructor
+   * @param {String}  reason
+   * @param {Object}  metadata
+   */
   constructor(reason, metadata) {
     super(STATUS_CODES.BAD_REQUEST, null, Object.assign({reason}, metadata));
   }
@@ -103,6 +108,11 @@ exports.RequestError = RequestError;
  * @extends HTTPError
  */
 class AuthorizationError extends HTTPError {
+  /**
+   * @constructor
+   * @param {String}  reason
+   * @param {Object}  metadata
+   */
   constructor(reason, metadata) {
     super(STATUS_CODES.UNAUTHORIZED, null, Object.assign({reason}, metadata));
   }
@@ -118,6 +128,12 @@ exports.AuthorizationError = AuthorizationError;
  * @extends HTTPError
  */
 class NotFoundError extends HTTPError {
+  /**
+   * @constructor
+   * @param {String}  method
+   * @param {String}  path
+   * @param {Object}  metadata
+   */
   constructor(method, path, metadata) {
     super(STATUS_CODES.NOT_FOUND, null, Object.assign({method, path}, metadata));
   }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,6 +1,7 @@
 'use strict';
-
 const Winston = require('winston');
+
+/** @module Log */
 
 /**
  * Logging provider
@@ -9,4 +10,52 @@ const Winston = require('winston');
  */
 const Log = global.Log = new Winston.Logger();
 
-Log.add(Winston.transports.Console, Config.get('log'));
+/*
+ * Ensure that capitalized levels don't crash the colorize routine
+ */
+Winston.addColors({
+  ERROR: 'red',
+  WARN: 'yellow',
+  HELP: 'cyan',
+  DATA: 'grey',
+  INFO: 'green',
+  DEBUG: 'blue',
+  PROMPT: 'grey',
+  VERBOSE: 'cyan',
+  INPUT: 'grey',
+  SILLY: 'magenta'
+});
+
+/**
+ * Log formatting to match levels used by Logback
+ */
+class Logback extends Winston.transports.Console {
+  /**
+   * @constructor
+   * @param  {Object} options
+   */
+  constructor(options) {
+    super(Object.assign({
+      colorize: false,
+      timestamp: true,
+      json: true,
+      stringify: true
+    }, options));
+  }
+
+  /**
+   * Wrap the log method to uppercase `level`
+   *
+   * @see {@link https://github.com/winstonjs/winston/blob/master/lib/winston/transports/console.js#L91}
+   *
+   * @param  {String} level
+   * @param  {String} msg
+   * @param  {Object} meta
+   * @param  {Function} callback
+   */
+  log(level, msg, meta, callback) {
+    super.log(level.toUpperCase(), msg, meta, callback);
+  }
+}
+
+Log.add(Logback, Config.get('log'));

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -49,20 +49,26 @@ function authn(options) {
 
   db.on('error', (err) => Log.error(err));
 
+  Log.info(`Using local authentication controller with database ${db.path}`);
+
   // Return a request handler
   return function handle(req, res, next) {
-    Log.info('Local token validator');
+    const identifier = req.identifier;
+
+    Log.debug('Enforcing local token validator', {identifier});
 
     validate(skew, req);
-
     // TODO Validate body digest signature
-
     authorization(req);
 
     const signature = new Signature(algorithm, req);
 
     signature.sign(db.lookup(req.identity));
+    Log.debug(`Request Signature: ${req.signature}`, {identifier});
+    Log.debug(`Challenge Signature: ${signature.signature}`, {identifier});
+
     signature.verify(req.signature);
+    Log.debug('Authenticated. Forwarding request', {identifier});
 
     next();
   };
@@ -94,12 +100,17 @@ function validate(skew, request) {
   // Verify that the request date is close to $NOW
   const now = Date.now();
 
+  Log.debug(`Date skew ${now - request.date.getTime()}ms`);
   if (Math.abs(now - request.date.getTime()) > skew) {
     throw new Errors.AuthorizationError('Request data skew is too large');
   }
 }
 
-// Parse authorization header and validate
+/**
+ * Parse the Authorization header and attach parameters to the request object
+ *
+ * @param  {HTTP.IncomingMessage} request The request to validate
+ */
 function authorization(request) {
   const parts = request.headers.authorization.split(' ');
 
@@ -110,6 +121,8 @@ function authorization(request) {
   if (parts[0] !== AUTHN_PROTOCOL) {
     throw new Errors.AuthorizationError(`Invalid authentication protocol ${parts[0]}`);
   }
+
+  Log.debug(`Using Authorization Scheme: ${parts[0]}`);
 
   /*
    * TODO The `Buffer()`` constructor is going to become deprecated, but
@@ -128,4 +141,5 @@ function authorization(request) {
 
 exports.Store = Store;
 exports.authn = authn;
+exports.authorization = authorization;
 exports.validate = validate;

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -87,14 +87,18 @@ function authn(options) {
 function validate(skew, request) {
   REQUIRED_HEADERS.forEach(function check(header) {
     if (!request.headers.hasOwnProperty(header)) {
-      throw new Errors.RequestError(`Missing header ${header}`);
+      throw new Errors.RequestError(`Missing header ${header}`, {
+        identifier: request.identifier
+      });
     }
   });
 
   // Validate Date header
   request.date = new Date(request.headers.date);
   if (isNaN(request.date)) {
-    throw new Errors.RequestError('Invalid Date header');
+    throw new Errors.RequestError('Invalid Date header', {
+      identifier: request.identifier
+    });
   }
 
   // Verify that the request date is close to $NOW
@@ -102,7 +106,9 @@ function validate(skew, request) {
 
   Log.debug(`Date skew ${now - request.date.getTime()}ms`);
   if (Math.abs(now - request.date.getTime()) > skew) {
-    throw new Errors.AuthorizationError('Request data skew is too large');
+    throw new Errors.AuthorizationError('Request data skew is too large', {
+      identifier: request.identifier
+    });
   }
 }
 
@@ -115,14 +121,20 @@ function authorization(request) {
   const parts = request.headers.authorization.split(' ');
 
   if (!parts.length || parts.length !== 2) {
-    throw new Errors.RequestError('Invalid Authorization header');
+    throw new Errors.RequestError('Invalid Authorization header', {
+      identifier: request.identifier
+    });
   }
 
   if (parts[0] !== AUTHN_PROTOCOL) {
-    throw new Errors.AuthorizationError(`Invalid authentication protocol ${parts[0]}`);
+    throw new Errors.AuthorizationError(`Invalid authentication protocol ${parts[0]}`, {
+      identifier: request.identifier
+    });
   }
 
-  Log.debug(`Using Authorization Scheme: ${parts[0]}`);
+  Log.debug(`Using Authorization Scheme: ${parts[0]}`, {
+    identifier: request.identifier
+  });
 
   /*
    * TODO The `Buffer()`` constructor is going to become deprecated, but
@@ -132,7 +144,9 @@ function authorization(request) {
   const parameters = Buffer(parts[1], 'base64').toString('utf8').split(':'); // eslint-disable-line new-cap
 
   if (!parameters.length || parameters.length !== 2) {
-    throw new Errors.AuthorizationError('Invalid authentication parameters');
+    throw new Errors.AuthorizationError('Invalid authentication parameters', {
+      identifier: request.identifier
+    });
   }
 
   request.identity = parameters[0];

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -15,26 +15,27 @@ class Signature {
    */
   constructor(algorithm, request) {
     this.algorithm = algorithm;
+    const identifier = this.identifier = request.identifier;
 
     this.method = request.method.toUpperCase();
-    Log.debug(`Using method ${this.method}`);
+    Log.debug(`Using method ${this.method}`, {identifier});
 
     if (request.hasOwnProperty('url')) { this.uri = request.url; }
     else if (request.hasOwnProperty('path')) { this.uri = request.path; }
     else { throw new Errors.RequestError('Missing URI field'); }
-    Log.debug(`Using URI ${this.uri}`);
+    Log.debug(`Using URI ${this.uri}`, {identifier});
 
     this.host = request.headers.host;
-    Log.debug(`Using host ${this.host}`);
+    Log.debug(`Using host ${this.host}`, {identifier});
 
     this.date = String(request.date.getTime());
-    Log.debug(`Using date ${this.date}`);
+    Log.debug(`Using date ${this.date}`, {identifier});
 
     this.identity = request.identity;
-    Log.debug(`Using identity ${this.identity}`);
+    Log.debug(`Using identity ${this.identity}`, {identifier});
 
     this.digest = request.headers.digest;
-    Log.debug(`Using digest ${this.digest}`);
+    Log.debug(`Using digest ${this.digest}`, {identifier});
   }
 
   /**
@@ -66,7 +67,9 @@ class Signature {
    */
   verify(signature) {
     if (signature !== this.signature) {
-      throw new Errors.AuthorizationError('Invalid authentication factors');
+      throw new Errors.AuthorizationError('Invalid authentication factors', {
+        identifier: this.identifier
+      });
     }
   }
 }

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -20,9 +20,13 @@ class Signature {
     this.method = request.method.toUpperCase();
     Log.debug(`Using method ${this.method}`, {identifier});
 
-    if (request.hasOwnProperty('url')) { this.uri = request.url; }
-    else if (request.hasOwnProperty('path')) { this.uri = request.path; }
-    else { throw new Errors.RequestError('Missing URI field'); }
+    if (request.hasOwnProperty('url')) {
+      this.uri = request.url;
+    } else if (request.hasOwnProperty('path')) {
+      this.uri = request.path;
+    } else {
+      throw new Errors.RequestError('Missing URI field');
+    }
     Log.debug(`Using URI ${this.uri}`, {identifier});
 
     this.host = request.headers.host;

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -16,12 +16,25 @@ class Signature {
   constructor(algorithm, request) {
     this.algorithm = algorithm;
 
-    this.method = request.method;
-    this.uri = request.url;
+    this.method = request.method.toUpperCase();
+    Log.debug(`Using method ${this.method}`);
+
+    if (request.hasOwnProperty('url')) { this.uri = request.url; }
+    else if (request.hasOwnProperty('path')) { this.uri = request.path; }
+    else { throw new Errors.RequestError('Missing URI field'); }
+    Log.debug(`Using URI ${this.uri}`);
+
     this.host = request.headers.host;
+    Log.debug(`Using host ${this.host}`);
+
     this.date = String(request.date.getTime());
+    Log.debug(`Using date ${this.date}`);
+
     this.identity = request.identity;
+    Log.debug(`Using identity ${this.identity}`);
+
     this.digest = request.headers.digest;
+    Log.debug(`Using digest ${this.digest}`);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
     "eslint": "^3.6.1",
+    "eslint-config-rapid7": "^2.4.0",
     "istanbul": "^0.4.3",
     "jsdoc": "^3.4.0",
     "mocha": "^2.4.5"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "eslint": "^3.6.1",
     "eslint-config-rapid7": "^2.4.0",
     "istanbul": "^0.4.3",
     "jsdoc": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
+    "eslint": "^3.6.1",
     "eslint-config-rapid7": "^2.4.0",
+    "eslint-plugin-import": "^2.0.1",
     "istanbul": "^0.4.3",
     "jsdoc": "^3.4.0",
     "mocha": "^2.4.5"

--- a/package.json
+++ b/package.json
@@ -28,17 +28,14 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "^3.1.0",
-    "eslint-config-rapid7": "0.0.15",
-    "eslint-plugin-rapid7": "^5.0.1",
-    "eslint-plugin-react": "^3.14.0",
+    "eslint": "^3.6.1",
     "istanbul": "^0.4.3",
     "jsdoc": "^3.4.0",
     "mocha": "^2.4.5"
   },
   "dependencies": {
     "nconf": "^0.8.4",
+    "node-libuuid": "^2.0.0",
     "winston": "^2.2.0"
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,9 +1,9 @@
 {
   "rules": {
-    "rapid7/static-magic-numbers": 0,
     "max-nested-callbacks": 0,
     "no-unused-expressions": 0,
-    "no-unused-vars": 0
+    "no-unused-vars": 0,
+    "require-jsdoc": 0
   },
   "env": {
     "mocha": true

--- a/test/03-signature.js
+++ b/test/03-signature.js
@@ -1,38 +1,74 @@
 'use strict';
 
 require('./resource/config');
+require('./resource/log');
 
 const Errors = require('../lib/errors');
-const Fixtures = require('./resource/fixtures');
-
 const Signature = require('../lib/signature');
 const expect = require('chai').expect;
 
-describe('lib/signature', function _signature() {
-  const signature = new Signature(Config.get('local:algorithm'), {
-    method: Fixtures.SIGNATURE.METHOD,
-    url: Fixtures.SIGNATURE.URL,
-    date: new Date(Fixtures.SIGNATURE.DATE),
-    headers: {
-      host: Fixtures.SIGNATURE.HOST,
-      digest: Fixtures.SIGNATURE.DIGEST
-    },
-    identity: Fixtures.DB.KEY
-  });
+const fixture = {
+  method: 'GET',
+  url: '/after/it',
+  date: new Date('Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)'),
+  headers: {
+    host: 'localhost',
+    digest: 'sha256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+  },
+  identity: '7bf9708aa51b7f7859d0e68b6b62b8ab'
+};
 
-  it('generates a base64 signature string', function behavior() {
+const secret = '6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq';
+const signed = 'AuICfpC1IcSBDoFYh/wjc+pgsmfd2t8EGng+n0FK3Tk=';
+
+describe('lib/signature', function() {
+  const signature = new Signature(Config.get('local:algorithm'), fixture);
+
+  it('generates a base64 signature string', function() {
     expect(signature.signature).to.be.undefined;
-    signature.sign(Fixtures.DB.SECRET);
+    signature.sign(secret);
 
     expect(signature.signature).to.match(/^[a-zA-Z0-9\/\+=]+$/);
-    expect(signature.signature).to.equal(Fixtures.SIGNATURE.SIGNATURE);
+    expect(signature.signature).to.equal(signed);
   });
 
-  it('validates a request signature', function behavior() {
-    expect(() => signature.verify(Fixtures.SIGNATURE.SIGNATURE)).to.not.throw();
+  it('uses a `path` request parameter if `url` is not defined', function() {
+    const pathFixture = Object.assign({
+      path: fixture.url
+    }, fixture);
+
+    delete pathFixture.url;
+
+    const signatureUsesPath = new Signature(Config.get('local:algorithm'), pathFixture);
+
+    signatureUsesPath.sign(secret);
+    expect(signatureUsesPath.signature).to.equal(signed);
   });
 
-  it('throws an error for an invalid request signature', function behavior() {
+  it('favors the `url` request parameter over `path`', function() {
+    const signatureFavorsURL = new Signature(Config.get('local:algorithm'), Object.assign({
+      path: '/foo/bar/baz'
+    }, fixture));
+
+    signatureFavorsURL.sign(secret);
+    expect(signatureFavorsURL.signature).to.equal(signed);
+  });
+
+  it('raises an exception if neither `path` nor `url` parameters are present', function() {
+    const pathFixture = Object.assign({}, fixture);
+
+    delete pathFixture.url;
+
+    expect(() => {
+      new Signature(Config.get('local:algorithm'), pathFixture);
+    }).to.throw(Errors.RequestError);
+  });
+
+  it('validates a request signature', function() {
+    expect(() => signature.verify(signed)).to.not.throw();
+  });
+
+  it('throws an error for an invalid request signature', function() {
     expect(() => signature.verify('asldfasdflkjhasdlfkjhasdlfkjhasdflk')).to.throw(Errors.AuthorizationError);
   });
 });

--- a/test/05-correlation-id.js
+++ b/test/05-correlation-id.js
@@ -1,0 +1,51 @@
+'use strict';
+
+require('./resource/config');
+require('./resource/log');
+
+// const Errors = require('../lib/errors');
+const HTTP = require('./resource/http');
+
+const Correlation = require('../lib/control/correlation');
+const Layer = require('../lib/control/layer');
+const expect = require('chai').expect;
+
+/*
+ * Create an app controller with the correlation middleware attached
+ */
+const app = Layer.create();
+
+app.use(Correlation.create({
+  header: 'correlation-id'
+}));
+
+describe('lib/control/correlation', function() {
+  describe('controller', function() {
+    it('throws a ReferenceError if the header parameter is missing', function() {
+      expect(() => Correlation.create()).to.throw(ReferenceError);
+    });
+
+    it('generates a new UUID if the request does not have a correlation header', function(done) {
+      HTTP.bench({}, app)
+        .response((req, res) => {
+          expect(req.identifier).to.be.a('string');
+          expect(req.headers).to.contain.keys('correlation-id');
+          expect(req.identifier).to.equal(req.headers['correlation-id']);
+        })
+        .finally(done);
+    });
+
+    it('detects a correlation header from downstream and adds it to the request', function(done) {
+      HTTP.bench({
+        headers: {
+          'correlation-id': 'test-correlation-id'
+        }
+      }, app)
+        .response((req, res) => {
+          expect(req.identifier).to.be.a('string');
+          expect(req.identifier).to.equal('test-correlation-id');
+        })
+        .finally(done);
+    });
+  });
+});

--- a/test/resource/fixtures.js
+++ b/test/resource/fixtures.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  *  A valid signature and its input parameters for testing
  */

--- a/test/resource/http.js
+++ b/test/resource/http.js
@@ -1,5 +1,4 @@
 'use strict';
-
 /**
  * This check fails for assignment of values on an Object argument, and does not
  * allow for argument type-checking/default setters. */
@@ -101,7 +100,7 @@ exports.server = function _listen(ready) {
 
     req.on('data', (chunk) => chunks.push(chunk));
     req.on('end', (chunk) => {
-      if (chunk) chunks.push(chunk);
+      if (chunk) { chunks.push(chunk); }
       req.body = Buffer.concat(chunks).toString('utf8');
 
       if (handlers.hasOwnProperty(req.url)) {
@@ -155,6 +154,7 @@ exports.server = function _listen(ready) {
   };
 
   server.listen(0, '127.0.0.1', () => ready(server.address().port));
+
   return server;
 };
 


### PR DESCRIPTION
This PR encapsulates the work required to deploy a canary instance of turnstile.

Build/Deploy
- Adds a recipe to deploy from a GitHub HEAD
- Adds a recipe to deploy from a GitHub release artifact
- Adds a recipe to utilize a local copy of source, e.g. a synced VM folder

Logging and Audit
- Adds a configurable correlation identifier header
- Adds lots of debug logging
- Includes request identifiers in request-scoped logging
- Set default logging format to JSON

Misc
- Improves HTTPError classes' interfaces, allowing additional metadata fields to be passed to constructors
- Add a hacky curl-like CLI utility for testing the Turnstile interface
- LINT!

TravisCI
- Install build-essential and uuid-dev packages
- Make it build in an Ubuntu 14.04 environment for header/linking compatibility
