### PR TITLE
Refactor tests to use the `HTTP.bench` interface

### DIFF
--- a/lib/control/forward.js
+++ b/lib/control/forward.js
@@ -4,7 +4,7 @@ const HTTP = require('http');
 
 /**
  * Proxy requests to an HTTP server
- * @module
+ * @module Forward
  */
 
 /**
@@ -21,18 +21,19 @@ exports.create = function(options) {
     hostname: 'localhost'
   }, options);
 
-  const port = Number(options.port);
-  const hostname = options.hostname;
-  const agent = new HTTP.Agent({
-    keepAlive: true
-  });
+  const context = {
+    port: Number(options.port),
+    hostname: options.hostname,
+    agent: new HTTP.Agent({
+      keepAlive: true
+    })
+  };
 
-  if (!port) { throw new TypeError('Option `port` must be a number'); }
+  if (!context.port) { throw new TypeError('Option `port` must be a number'); }
+  Log.info(`Using HTTP forwarder to ${context.hostname}:${context.port}`);
 
-  Log.info(`Using HTTP forwarder to ${hostname}:${port}`);
-
-  return function handle(req, res, next) {
-    Log.debug(`Forwarding request to ${hostname}:${port}${req.url}`, {
+  const handle = (function(req, res, next) {
+    Log.debug(`Forwarding request to ${this.hostname}:${this.port}${req.url}`, {
       identifier: req.identifier,
       method: req.method,
       path: req.url
@@ -43,7 +44,9 @@ exports.create = function(options) {
       path: req.url,
       headers: req.headers,
 
-      agent, hostname, port
+      agent: this.agent,
+      hostname: this.hostname,
+      port: this.port
     });
 
     forward.on('error', next);
@@ -63,5 +66,14 @@ exports.create = function(options) {
     });
 
     req.pipe(forward);
-  };
+  }).bind(context);
+
+  /*
+   * This allows options passed to the create wrapper to be
+   * modified later. It allows the test bench to set a randomly
+   * selected port number after its listener has started
+   */
+  handle.context = context;
+
+  return handle;
 };

--- a/lib/control/forward.js
+++ b/lib/control/forward.js
@@ -4,7 +4,7 @@ const HTTP = require('http');
 
 /**
  * Proxy requests to an HTTP server
- * @module Forward
+ * @module
  */
 
 /**

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -53,6 +53,14 @@ class HTTPError extends Error {
   }
 
   /**
+   * Generate a useful string for debugging
+   * @return {String}
+   */
+  toString() {
+    return `${this.name} (${this.code}): ${this.message}, ${JSON.stringify(this.metadata)}`;
+  }
+
+  /**
    * An error renderer control layer
    *
    * @param  {Error}                err  An Error that manifested in the request
@@ -91,7 +99,7 @@ class RequestError extends HTTPError {
    * @param {Object}  metadata
    */
   constructor(reason, metadata) {
-    super(STATUS_CODES.BAD_REQUEST, null, Object.assign({reason}, metadata));
+    super(STATUS_CODES.BAD_REQUEST, reason, metadata);
   }
 }
 
@@ -108,7 +116,7 @@ class AuthorizationError extends HTTPError {
    * @param {Object}  metadata
    */
   constructor(reason, metadata) {
-    super(STATUS_CODES.UNAUTHORIZED, null, Object.assign({reason}, metadata));
+    super(STATUS_CODES.UNAUTHORIZED, reason, metadata);
   }
 }
 
@@ -126,7 +134,7 @@ class NotFoundError extends HTTPError {
    * @param {Object}  metadata
    */
   constructor(method, path, metadata) {
-    super(STATUS_CODES.NOT_FOUND, null, Object.assign({method, path}, metadata));
+    super(STATUS_CODES.NOT_FOUND, `${method} ${path}`, Object.assign({method, path}, metadata));
   }
 }
 

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -47,7 +47,7 @@ exports.validate = function(skew, request) {
 
   Log.debug(`Date skew ${now - request.date.getTime()}ms`);
   if (Math.abs(now - request.date.getTime()) > skew) {
-    throw new Errors.AuthorizationError('Request data skew is too large', {
+    throw new Errors.AuthorizationError('Request date skew is too large', {
       identifier: request.identifier
     });
   }

--- a/test/01-errors.js
+++ b/test/01-errors.js
@@ -37,10 +37,8 @@ describe('lib/errors', function errors() {
 
       expect(error.code).to.equal(400);
       expect(error.name).to.equal('BadRequest');
-      expect(error.message).to.equal('Bad Request');
-      expect(error.metadata).to.eql({
-        reason: REASON
-      });
+      expect(error.message).to.equal(REASON);
+      expect(error.metadata).to.eql({});
     });
   });
 
@@ -51,10 +49,8 @@ describe('lib/errors', function errors() {
 
       expect(error.code).to.equal(401);
       expect(error.name).to.equal('Unauthorized');
-      expect(error.message).to.equal('Unauthorized');
-      expect(error.metadata).to.eql({
-        reason: REASON
-      });
+      expect(error.message).to.equal(REASON);
+      expect(error.metadata).to.eql({});
     });
   });
 
@@ -64,7 +60,7 @@ describe('lib/errors', function errors() {
 
       expect(error.code).to.equal(404);
       expect(error.name).to.equal('NotFound');
-      expect(error.message).to.equal('Not Found');
+      expect(error.message).to.equal('GET /after/it');
       expect(error.metadata).to.eql({
         method: 'GET',
         path: '/after/it'

--- a/test/02-layer.js
+++ b/test/02-layer.js
@@ -68,7 +68,7 @@ describe('lib/control/layer', function layer() {
     });
 
     app.use(function middleware(_req, _res, _next) {
-      done(Error('Control should not have entered next middleware'));
+      throw Error('Control should not have entered next middleware');
     });
 
     HTTP.bench(fixture.REQUEST, (req, res) => app(req, res))

--- a/test/02-layer.js
+++ b/test/02-layer.js
@@ -13,26 +13,23 @@ const expect = require('chai').expect;
 describe('lib/control/layer', function layer() {
   const fixture = Fixtures.HTTP[200];
 
-  it('responds with a `404: Not Found` response if no layers respond', function behavior(done) {
+  it('responds with a `404: Not Found` response if no layers respond', function(done) {
     const app = Layer.create();
 
-    HTTP.request(HTTP.path(), fixture.REQUEST)
-    .once('request', (req, res) => app(req, res))
-    .once('response', function response(res) {
-      expect(res.statusCode).to.equal(404);
-      expect(res.headers).to.contain.keys({'content-type': 'application/json'});
-      expect(res.headers).to.contain.keys('content-length');
-      expect(res.body).to.be.not.empty;
-
-      done();
-    });
+    HTTP.bench(fixture.REQUEST, (req, res) => app(req, res))
+      .response((req, res) => {
+        expect(res.statusCode).to.equal(404);
+        expect(res.headers).to.contain.keys({'content-type': 'application/json'});
+        expect(res.headers).to.contain.keys('content-length');
+        expect(res.body).to.be.not.empty;
+      })
+      .finally(done);
   });
 
   it('passes requests to handlers', function behavior(done) {
     const app = Layer.create();
 
-    HTTP.request(HTTP.path(), fixture.REQUEST)
-    .once('request', function request(req, res) {
+    HTTP.bench(fixture.REQUEST, (req, res) => {
       app.use(function middleware(_req, _res, next) {
         expect(_req).to.equal(req);
         expect(_res).to.equal(res);
@@ -41,79 +38,70 @@ describe('lib/control/layer', function layer() {
       });
 
       app(req, res);
-    }).on('response', () => done());
+    }).finally(done);
   });
 
-  it('advances to the next handler when `next()` is called', function behavior(done) {
+  it('advances to the next handler when `next()` is called', function(done) {
     const app = Layer.create();
 
-    HTTP.request(HTTP.path(), fixture.REQUEST)
-    .once('request', function request(req, res) {
-      app.use(function middleware(_req, _res, next) {
-        next();
-      });
+    app.use(function middleware(req, res, next) {
+      next();
+    });
 
+    HTTP.bench(fixture.REQUEST, (req, res) => {
       app.use(function middleware(_req, _res, next) {
         expect(_req).to.equal(req);
         expect(_res).to.equal(res);
 
-        done();
+        next();
       });
 
       app(req, res);
-    });
+    }).finally(done);
   });
 
-  it('stops advancing to the next handler when `next()` is called with an error', function behavior(done) {
+  it('stops advancing to the next handler when `next()` is called with an error', function(done) {
     const app = Layer.create();
 
-    HTTP.request(HTTP.path(), fixture.REQUEST)
-    .once('request', function request(req, res) {
-      app.use(function middleware(_req, _res, next) {
-        next(new Errors.AuthorizationError());
-      });
-
-      app.use(function middleware(_req, _res, _next) {
-        throw Error('What are you doing in here?!');
-      });
-
-      app(req, res);
-    })
-    .once('response', function response(res) {
-      expect(res.statusCode).to.equal(401);
-      expect(res.headers).to.contain.keys({'content-type': 'application/json'});
-      expect(res.headers).to.contain.keys('content-length');
-      expect(res.body).to.be.not.empty;
-
-      done();
+    app.use(function middleware(req, res, next) {
+      next(new Errors.AuthorizationError());
     });
+
+    app.use(function middleware(_req, _res, _next) {
+      done(Error('Control should not have entered next middleware'));
+    });
+
+    HTTP.bench(fixture.REQUEST, (req, res) => app(req, res))
+      .response((req, res) => {
+        expect(res.statusCode).to.equal(401);
+        expect(res.headers).to.contain.keys({'content-type': 'application/json'});
+        expect(res.headers).to.contain.keys('content-length');
+        expect(res.body).to.be.not.empty;
+      })
+      .finally(done);
   });
 
-  it('catches and returns errors thrown in handlers', function behavior(done) {
-    const ERROR_MESSAGE = 'What are you doing in here?!';
+  it('catches and returns errors thrown in handlers', function(done) {
     const app = Layer.create();
 
-    HTTP.request(HTTP.path(), fixture.REQUEST)
-    .once('request', function request(req, res) {
-      app.use(function middleware(_req_, _res_, _next_) {
-        throw Error(ERROR_MESSAGE);
-      });
-
-      app(req, res);
-    })
-    .once('response', function response(res) {
-      expect(res.statusCode).to.equal(500);
-      expect(res.headers).to.contain.keys({'content-type': 'application/json'});
-      expect(res.headers).to.contain.keys('content-length');
-
-      expect(res.body).to.be.a('string');
-
-      const error = JSON.parse(res.body);
-
-      expect(error.code).to.equal(500);
-      expect(error.message).to.equal(ERROR_MESSAGE);
-
-      done();
+    app.use(function middleware() {
+      throw Error('This is an unhandled middleware exception');
     });
+
+    HTTP.bench(fixture.REQUEST, (req, res) => app(req, res))
+      .response((req, res) => {
+        expect(res.statusCode).to.equal(500);
+        expect(res.headers).to.contain.keys({'content-type': 'application/json'});
+        expect(res.headers).to.contain.keys('content-length');
+
+        expect(res.body).to.be.not.empty;
+        expect(res.body).to.be.a('string');
+
+        const error = JSON.parse(res.body);
+
+        expect(error.code).to.equal(500);
+        expect(error.message).to.equal('This is an unhandled middleware exception');
+      })
+      .finally(done);
   });
 });

--- a/test/04-forward.js
+++ b/test/04-forward.js
@@ -7,75 +7,87 @@ require('./resource/log');
 const Fixtures = require('./resource/fixtures');
 const HTTP = require('./resource/http');
 
-const Controller = require('../lib/control/forward');
+const Forward = require('../lib/control/forward');
 const expect = require('chai').expect;
 
-describe('lib/control/forward', function middleware() {
-  describe('controller', function _controller() {
-    let server, controller;
+const controller = Forward.create({
+  hostname: Config.get('service:hostname'),
+  port: 80
+});
+const server = HTTP.server();
 
-    // Set up a test HTTP server
-    before(function _before(done) {
-      server = HTTP.server(function listening(port) {
-        controller = Controller.create(Object.assign({
-          hostname: Config.get('service:hostname'),
-          port
-        }));
-
+describe('lib/control/forward', function() {
+  describe('controller', function() {
+    before((done) => {
+      server.start((port) => {
+        controller.context.port = port;
         done();
       });
     });
-
     after(() => server.close());
 
-    it('throws a TypeError if options.port is not a Number', function behavior() {
+    it('throws a TypeError if options.port is not a Number', function() {
       expect(function _expect() {
-        Controller.create(Object.assign({
+        Forward.create({
           hostname: Config.get('service:hostname'),
           port: 'lalalala'
-        }));
+        });
       }).to.throw(TypeError);
     });
 
-    it('connects to an HTTP server and forwards a request', function behavior(done) {
+    it('connects to an HTTP server and forwards a request', function(done) {
       const fixture = Fixtures.HTTP[200];
+      const request = Object.assign({}, fixture.REQUEST, {
+        url: server.handle(Fixtures.HTTP[200])
+      });
 
-      HTTP.request(server.handle(fixture), fixture.REQUEST)
-      .once('request', function request(req, res) {
-        controller(req, res, function next(err) {
-          expect(err).to.be.undefined;
+      HTTP.bench(request, (req, res) => controller(req, res, function(err) {
+        expect(err).to.be.undefined;
+      }))
+        .response((req, res) => {
+          expect(res.statusCode).to.equal(fixture.RESPONSE.code);
+          expect(res.headers).to.contain.keys({'content-type': fixture.RESPONSE.type});
+          expect(res.headers).to.contain.keys('content-length');
+          expect(res.body).to.equal(fixture.RESPONSE.body);
+        })
+        .finally(done);
+    });
+
+    [301, 302, 400, 401, 403, 404, 500, 501].forEach(function(code) {
+      it(`handles a ${code} response from the server`, function(done) {
+        const fixture = Fixtures.HTTP[code];
+        const request = Object.assign({}, fixture.REQUEST, {
+          url: server.handle(Fixtures.HTTP[code])
         });
-      })
-      .once('response', function response(res) {
-        expect(res.statusCode).to.equal(fixture.RESPONSE.CODE);
-        expect(res.headers).to.contain.keys({'content-type': fixture.RESPONSE.TYPE});
-        expect(res.headers).to.contain.keys('content-length');
-        expect(res.body).to.equal(fixture.RESPONSE.BODY);
 
-        done();
+        HTTP.bench(request, (req, res) => controller(req, res, function(err) {
+          expect(err).to.be.undefined;
+        }))
+          .response((req, res) => {
+            expect(res.statusCode).to.equal(fixture.RESPONSE.code);
+            expect(res.headers).to.contain.keys({'content-type': fixture.RESPONSE.type});
+            expect(res.headers).to.contain.keys('content-length');
+            expect(res.body).to.equal(fixture.RESPONSE.body);
+          })
+          .finally(done);
       });
     });
 
-    [301, 302, 304, 400, 401, 403, 404, 500, 501].forEach(function _cases(code) {
-      it(`handles a ${code} response from the server`, function behavior(done) {
-        HTTP.request(server.handle(Fixtures.HTTP[code]), Fixtures.HTTP[code].REQUEST)
-        .once('request', function request(req, res) {
-          controller(req, res, function next(err) {
-            expect(err).to.be.undefined;
-          });
-        })
-        .once('response', function response(res) {
-          expect(res.statusCode).to.equal(Fixtures.HTTP[code].RESPONSE.CODE);
-          expect(res.headers).to.contain.keys({'content-type': Fixtures.HTTP[code].RESPONSE.TYPE});
-
-          if (Fixtures.HTTP[code].RESPONSE.BODY) {
-            expect(res.headers).to.contain.keys('content-length');
-            expect(res.body).to.equal(Fixtures.HTTP[code].RESPONSE.BODY);
-          }
-
-          done();
-        });
+    it(`handles a 304 response from the server`, function(done) {
+      const fixture = Fixtures.HTTP[304];
+      const request = Object.assign({}, fixture.REQUEST, {
+        url: server.handle(Fixtures.HTTP[304])
       });
+
+      HTTP.bench(request, (req, res) => controller(req, res, function(err) {
+        expect(err).to.be.undefined;
+      }))
+        .response((req, res) => {
+          expect(res.statusCode).to.equal(fixture.RESPONSE.code);
+          expect(res.headers).to.contain.keys({'content-type': fixture.RESPONSE.type});
+          expect(res.body).to.equal(fixture.RESPONSE.body);
+        })
+        .finally(done);
     });
   });
 });

--- a/test/10-local-store.js
+++ b/test/10-local-store.js
@@ -3,9 +3,16 @@
 require('./resource/config');
 
 const Errors = require('../lib/errors');
-const Fixtures = require('./resource/fixtures');
 const Local = require('../lib/provider/local');
 const expect = require('chai').expect;
+
+/*
+ * Matches parameters in the keys.json resource
+ */
+const fixture = {
+  key: '7bf9708aa51b7f7859d0e68b6b62b8ab',
+  secret: '6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq'
+};
 
 describe('lib/local/store', function storage() {
   describe('Events', function events() {
@@ -41,8 +48,8 @@ describe('lib/local/store', function storage() {
     });
 
     it('`lookup` returns a secret when it is called with a valid key', function behavior() {
-      expect(() => db.lookup(Fixtures.DB.KEY)).to.not.throw();
-      expect(db.lookup(Fixtures.DB.KEY)).to.equal(Fixtures.DB.SECRET);
+      expect(() => db.lookup(fixture.key)).to.not.throw();
+      expect(db.lookup(fixture.key)).to.equal(fixture.secret);
     });
   });
 });

--- a/test/11-local-auth.js
+++ b/test/11-local-auth.js
@@ -46,11 +46,12 @@ describe('lib/provider/local', function() {
       });
 
       HTTP.bench(missingHeaders, (req, res) => validateWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.RequestError);
-          expect(err.message).to.equal('Missing header authorization');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.RequestError);
+            expect(err.message).to.equal('Missing header authorization');
+          })
         .finally(done);
     });
 
@@ -62,21 +63,23 @@ describe('lib/provider/local', function() {
       });
 
       HTTP.bench(invalidDate, (req, res) => validateWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.RequestError);
-          expect(err.message).to.equal('Invalid Date header');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.RequestError);
+            expect(err.message).to.equal('Invalid Date header');
+          })
         .finally(done);
     });
 
     it('fails if the date header is more than SKEW ms from Now', function(done) {
       HTTP.bench(fixture, (req, res) => validateWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.AuthorizationError);
-          expect(err.message).to.equal('Request date skew is too large');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.AuthorizationError);
+            expect(err.message).to.equal('Request date skew is too large');
+          })
         .finally(done);
     });
   });
@@ -90,11 +93,12 @@ describe('lib/provider/local', function() {
       });
 
       HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.RequestError);
-          expect(err.message).to.equal('Invalid Authorization header');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.RequestError);
+            expect(err.message).to.equal('Invalid Authorization header');
+          })
         .finally(done);
     });
 
@@ -106,11 +110,12 @@ describe('lib/provider/local', function() {
       });
 
       HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.AuthorizationError);
-          expect(err.message).to.equal('Invalid authentication protocol Rapid7-HMAC-V1-FOOBAR');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.AuthorizationError);
+            expect(err.message).to.equal('Invalid authentication protocol Rapid7-HMAC-V1-FOOBAR');
+          })
         .finally(done);
     });
 
@@ -122,11 +127,12 @@ describe('lib/provider/local', function() {
       });
 
       HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
-        .then(() => done(Error('Validation should have failed')))
-        .catch((err) => {
-          expect(err).to.be.instanceof(Errors.AuthorizationError);
-          expect(err.message).to.equal('Invalid authentication parameters');
-        })
+        .then(
+          () => { throw Error('Validation should have failed'); },
+          (err) => {
+            expect(err).to.be.instanceof(Errors.AuthorizationError);
+            expect(err.message).to.equal('Invalid authentication parameters');
+          })
         .finally(done);
     });
 

--- a/test/11-local-auth.js
+++ b/test/11-local-auth.js
@@ -5,129 +5,166 @@ require('./resource/log');
 
 const HTTP = require('./resource/http');
 const Errors = require('../lib/errors');
-const Fixtures = require('./resource/fixtures');
 
 const Controller = require('../lib/provider/local');
 const Signature = require('../lib/signature');
 const expect = require('chai').expect;
 
-describe('lib/provider/local', function middleware() {
-  describe('validate', function validate() {
-    const req = new HTTP.IncomingMessage();
+const identity = '7bf9708aa51b7f7859d0e68b6b62b8ab';
+const secret = '6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq';
+const signed = 'AuICfpC1IcSBDoFYh/wjc+pgsmfd2t8EGng+n0FK3Tk=';
 
-    beforeEach(function setup() {
-      req.method = Fixtures.SIGNATURE.METHOD;
-      req.url = Fixtures.SIGNATURE.URL;
+const authorization = Buffer.from(`${identity}:${signed}`, 'utf8').toString('base64');
 
-      /*
-       * TODO The `Buffer()`` constructor is going to become deprecated, but
-       * `Buffer.from(str, enc)` isn't fully implemented yet. Need to replace this
-       * call someday.
-       */
-      const authorization = Buffer( // eslint-disable-line new-cap
-        Fixtures.DB.KEY + ':' +
-        Fixtures.SIGNATURE.SIGNATURE, 'utf8'
-      ).toString('base64');
+const fixture = {
+  method: 'GET',
+  url: '/after/it',
+  date: new Date('Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)'),
+  headers: {
+    host: 'localhost',
+    date: 'Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)',
+    digest: 'sha256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
+    authorization: `Rapid7-HMAC-V1-SHA256 ${authorization}`
+  }
+};
 
-      req.headers = {
-        authorization: `Rapid7-HMAC-V1-SHA256 ${authorization}`,
-        date: Fixtures.SIGNATURE.DATE,
-        digest: 'sha256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
-        host: Fixtures.SIGNATURE.HOST
-      };
+function validateWrapper(req, res) {
+  Controller.validate(5000, req);
+  res.end();
+}
+
+function authorizationWrapper(req, res) {
+  Controller.authorization(req);
+  res.end();
+}
+
+describe('lib/provider/local', function() {
+  describe('validation', function() {
+    it('fails if required headers are missing', function(done) {
+      const missingHeaders = Object.assign({}, fixture, {
+        headers: {}
+      });
+
+      HTTP.bench(missingHeaders, (req, res) => validateWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.RequestError);
+          expect(err.message).to.equal('Missing header authorization');
+        })
+        .finally(done);
     });
 
-    it('fails if required headers are missing', function behavior() {
-      delete req.headers.authorization;
+    it('fails if the date header is not a valid date string', function(done) {
+      const invalidDate = Object.assign({}, fixture, {
+        headers: Object.assign({}, fixture.headers, {
+          date: 'asdfasdfasdfasdf'
+        })
+      });
 
-      expect(() => Controller.validate(5000, req)).to.throw(Errors.RequestError);
+      HTTP.bench(invalidDate, (req, res) => validateWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.RequestError);
+          expect(err.message).to.equal('Invalid Date header');
+        })
+        .finally(done);
     });
 
-    it('fails if the date header is not a valid data string', function behavior() {
-      req.headers.date = 'asdfasdfasdfasdf';
+    it('fails if the date header is more than SKEW ms from Now', function(done) {
+      HTTP.bench(fixture, (req, res) => validateWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.AuthorizationError);
+          expect(err.message).to.equal('Request date skew is too large');
+        })
+        .finally(done);
+    });
+  });
 
-      expect(() => Controller.validate(5000, req)).to.throw(Errors.RequestError);
+  describe('authorization', function() {
+    it('fails if the Authorization header is invalid', function(done) {
+      const invalidAuth = Object.assign({}, fixture, {
+        headers: {
+          authorization: 'INVLAID_HEADER'
+        }
+      });
+
+      HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.RequestError);
+          expect(err.message).to.equal('Invalid Authorization header');
+        })
+        .finally(done);
     });
 
-    it('fails if the date header is more than SKEW ms from Now', function behavior() {
-      expect(() => Controller.validate(5000, req)).to.throw(Errors.AuthorizationError);
+    it('fails if the Authorization protocol is unsupported', function(done) {
+      const invalidAuth = Object.assign({}, fixture, {
+        headers: {
+          authorization: 'Rapid7-HMAC-V1-FOOBAR randomBase64foobarbaz'
+        }
+      });
+
+      HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.AuthorizationError);
+          expect(err.message).to.equal('Invalid authentication protocol Rapid7-HMAC-V1-FOOBAR');
+        })
+        .finally(done);
     });
 
-    it('passes if headers are valid', function behavior() {
-      req.headers.date = (new Date()).toString();
+    it('fails if the Authorization parameters are invalid', function(done) {
+      const invalidAuth = Object.assign({}, fixture, {
+        headers: {
+          authorization: 'Rapid7-HMAC-V1-SHA256 randomBase64foobarbaz'
+        }
+      });
 
-      expect(() => Controller.validate(5000, req)).to.not.throw();
+      HTTP.bench(invalidAuth, (req, res) => authorizationWrapper(req, res))
+        .then(() => done(Error('Validation should have failed')))
+        .catch((err) => {
+          expect(err).to.be.instanceof(Errors.AuthorizationError);
+          expect(err.message).to.equal('Invalid authentication parameters');
+        })
+        .finally(done);
+    });
+
+    it('passes if headers are valid', function(done) {
+      const valid = Object.assign({}, fixture, {
+        headers: Object.assign({}, fixture.headers, {
+          date: (new Date()).toString()
+        })
+      });
+
+      HTTP.bench(valid, (req, res) => validateWrapper(req, res)).finally(done);
     });
   });
 
   describe('controller', function control() {
-    const req = new HTTP.IncomingMessage();
-    const res = new HTTP.ServerResponse(function handler() {});
-
     const controller = Controller.authn(Config.get('local'));
 
-    beforeEach(function setup() {
-      const now = (new Date()).toString();
-
-      req.method = Fixtures.SIGNATURE.METHOD;
-      req.url = Fixtures.SIGNATURE.URL;
-
-      req.headers = {
-        date: now,
-        digest: 'sha256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
-        host: Fixtures.SIGNATURE.HOST
-      };
-
-      req.date = new Date(now);
-      req.identity = Fixtures.DB.KEY;
-
-      const signature = new Signature(Config.get('local:algorithm'), req);
-
-      signature.sign(Fixtures.DB.SECRET);
-      req.signature = signature.signature;
-
-      /*
-       * TODO The `Buffer()`` constructor is going to become deprecated, but
-       * `Buffer.from(str, enc)` isn't fully implemented yet. Need to replace this
-       * call someday.
-       */
-      const authorization = Buffer( // eslint-disable-line new-cap
-        Fixtures.DB.KEY + ':' +
-        signature.signature, 'utf8'
-      ).toString('base64');
-
-      req.headers.authorization = `Rapid7-HMAC-V1-SHA256 ${authorization}`;
-    });
-
-    it('passes a valid request to the next middleware', function behavior(done) {
-      controller(req, res, function next(err) {
-        expect(err).to.be.undefined;
-        done();
+    it('passes a valid request to the next middleware', function(done) {
+      // Set the date key in headers and request. This is required to generate
+      // a valid request signature for testing.
+      const date = (new Date()).toString();
+      const valid = Object.assign({}, fixture, {
+        headers: Object.assign({}, fixture.headers, {date}),
+        identity,
+        date: new Date(date)
       });
-    });
 
-    it('raises an error if the Authorization header is invalid', function behavior() {
-      req.headers.authorization = 'INVLAID_HEADER';
+      const signature = new Signature(Config.get('local:algorithm'), valid);
+      const authorization = Buffer.from(`${identity}:${signature.sign(secret)}`, 'utf8').toString('base64');
 
-      expect(() => controller(req, res, function next() {})).to.throw(Errors.RequestError);
-    });
+      valid.headers.authorization = `Rapid7-HMAC-V1-SHA256 ${authorization}`;
 
-    it('raises an error if the Authorization protocol is unsupported', function behavior() {
-      req.headers.authorization = 'Rapid7-HMAC-V1-FOOBAR randomBase64foobarbaz';
-
-      expect(() => controller(req, res, function next() {})).to.throw(Errors.AuthorizationError);
-    });
-
-    it('raises an error if the Authorization parameters are invalid', function behavior() {
-      req.headers.authorization = 'Rapid7-HMAC-V1-SHA256 randomBase64foobarbaz';
-
-      expect(() => controller(req, res, function next() {})).to.throw(Errors.AuthorizationError);
-    });
-
-    it('raises an error if the date skew is too high', function behavior() {
-      req.headers.date = Fixtures.SIGNATURE.DATE;
-
-      expect(() => controller(req, res, function next() {})).to.throw(Errors.AuthorizationError);
+      HTTP.bench(valid, (req, res) => {
+        controller(req, res, function(err) {
+          expect(err).to.be.undefined;
+          res.end();
+        });
+      }).finally(done);
     });
   });
 });

--- a/test/resource/fixtures.js
+++ b/test/resource/fixtures.js
@@ -1,23 +1,4 @@
 'use strict';
-/**
- *  A valid signature and its input parameters for testing
- */
-exports.SIGNATURE = {
-  METHOD: 'GET',
-  URL: '/after/it',
-  DATE: 'Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)',
-  HOST: 'localhost',
-  DIGEST: 'sha256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
-  SIGNATURE: 'AuICfpC1IcSBDoFYh/wjc+pgsmfd2t8EGng+n0FK3Tk='
-};
-
-/**
- * An entry in ./keys.json to test against
- */
-exports.DB = {
-  KEY: '7bf9708aa51b7f7859d0e68b6b62b8ab',
-  SECRET: '6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq'
-};
 
 /**
  * HTTP Request/Response parameters
@@ -25,14 +6,14 @@ exports.DB = {
 exports.HTTP = {
   200: {
     REQUEST: {
-      METHOD: 'GET',
-      TYPE: 'text/plain',
-      BODY: 'knock knock'
+      method: 'GET',
+      type: 'text/plain',
+      body: 'knock knock'
     },
     RESPONSE: {
-      CODE: 200,
-      TYPE: 'text/plain',
-      BODY: 'Hello, world!'
+      code: 200,
+      type: 'text/plain',
+      body: 'Hello, world!'
     }
   }
 };
@@ -43,7 +24,7 @@ exports.HTTP = {
     RESPONSE: Object.assign({}, exports.HTTP[200].RESPONSE)
   };
 
-  exports.HTTP[code].RESPONSE.CODE = code;
+  exports.HTTP[code].RESPONSE.code = code;
 });
 
-delete exports.HTTP[304].RESPONSE.BODY;
+exports.HTTP[304].RESPONSE.body = '';


### PR DESCRIPTION
The original HTTP test bench I wrote didn't work well with Mocha and the Chai `expect` interface. If assertions failed, the errors that they threw were hidden and the test case would time out instead of reporting useful output.
1. The new test bench captures and reports failures to the Mocha harness correctly, making failures _much_ easier to diagnose. It also replaces some of the boilerplate that was required for the previous interface.
2. The HTTP error classes have been modified slightly to render useful messages when they are captured by the test harness.
3. The `forward` controller module has been modified to allow its tests to set its client port after a test-server has started with a random port.
