### PR TITLE
Move build-chain dependencies into local recipe

### DIFF
--- a/cookbook/recipes/_install_github_ref.rb
+++ b/cookbook/recipes/_install_github_ref.rb
@@ -33,6 +33,10 @@ execute 'extract source' do
   notifies :run, 'execute[npm install]', :immediate
 end
 
+## node-libuuid support
+package 'build-essential'
+package 'uuid-dev'
+
 ## Install module dependencies
 execute 'npm install' do
   command '/usr/bin/npm install'

--- a/cookbook/recipes/_install_local.rb
+++ b/cookbook/recipes/_install_local.rb
@@ -12,6 +12,10 @@ Chef::Application.fatal!(
   "Mount the Turnstile application at #{node['turnstile']['paths']['directory']}"
 ) unless ::Dir.exist?(node['turnstile']['paths']['directory'])
 
+## node-libuuid support
+package 'build-essential'
+package 'uuid-dev'
+
 execute 'npm install' do
   command '/usr/bin/npm install'
   cwd node['turnstile']['paths']['directory']

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -24,10 +24,6 @@ end
 package 'nodejs'
 #######################
 
-## node-libuuid support
-package 'build-essential'
-package 'uuid-dev'
-
 node.default['turnstile']['version'] = cookbook_version
 
 group node['turnstile']['group'] do


### PR DESCRIPTION
The build-essential and uuid-dev packages should only be installed
where `npm install` must be executed. Our CI will have these
dependencies met for packaging.

The node-libuuid package statically links to uuid.cc at install-time
and doesn't require any external objects thereafter.