### PR TITLE
Fixed dependencies to tilde range.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   },
   "homepage": "https://github.com/rapid7/turnstile#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "coveralls": "^2.11.9",
-    "eslint": "^3.6.1",
-    "eslint-config-rapid7": "^2.4.0",
-    "eslint-plugin-import": "^2.0.1",
-    "istanbul": "^0.4.3",
-    "jsdoc": "^3.4.0",
-    "mocha": "^2.4.5"
+    "chai": "~3.5.0",
+    "coveralls": "~2.11.9",
+    "eslint": "~3.7.0",
+    "eslint-config-rapid7": "~2.4.0",
+    "eslint-plugin-import": "~2.0.1",
+    "istanbul": "~0.4.3",
+    "jsdoc": "~3.4.0",
+    "mocha": "~2.4.5"
   },
   "dependencies": {
-    "nconf": "^0.8.4",
-    "node-libuuid": "^2.0.0",
-    "winston": "^2.2.0"
+    "nconf": "~0.8.4",
+    "node-libuuid": "~2.0.0",
+    "winston": "~2.2.0"
   }
 }


### PR DESCRIPTION
This PR locks the project dependencies to [tilde ranges](https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1) rather than using the more permissive [caret ranges](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004).