### PR TITLE
Feature: Prevent weak hashing algorithms

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 
+const Errors = require('../lib/errors');
+const SUPPORTED_ALGORITHMS = ['SHA256', 'SHA512'];
+
 require('../lib/config');
+if (['SHA256', 'SHA512'].filter((a) => a === Config.get('local:algorithm').toUpperCase()).length === 0) {
+  const message = `Turnstile currently supports the following encryption algorithms: ${SUPPORTED_ALGORITHMS.join(', ')}`;
+
+  throw new Errors.UnsupportedAlgorithmError(message, Config.get('local:algorithm').toUpperCase());
+}
+
 require('../lib/log');
 
 const app = require('../lib/control/layer').create();

--- a/bin/server
+++ b/bin/server
@@ -5,10 +5,12 @@ const Errors = require('../lib/errors');
 const SUPPORTED_ALGORITHMS = ['SHA256', 'SHA512'];
 
 require('../lib/config');
-if (['SHA256', 'SHA512'].filter((a) => a === Config.get('local:algorithm').toUpperCase()).length === 0) {
-  const message = `Turnstile currently supports the following encryption algorithms: ${SUPPORTED_ALGORITHMS.join(', ')}`;
+const algorithm = Config.get('local:algorithm');
 
-  throw new Errors.UnsupportedAlgorithmError(message, Config.get('local:algorithm').toUpperCase());
+if (SUPPORTED_ALGORITHMS.indexOf(algorithm.toUpperCase()) === -1) {
+  const message = `Turnstile currently supports the following encryption algorithms: ${SUPPORTED_ALGORITHMS.join(', ')}. You specified ${algorithm}.`;
+
+  throw new Errors.UnsupportedAlgorithmError(message, algorithm.toUpperCase());
 }
 
 require('../lib/log');

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -141,20 +141,21 @@ class NotFoundError extends HTTPError {
 exports.NotFoundError = NotFoundError;
 
 /**
- * An error for methods that need to be implemented but haven't been.
- * @extends {Error}
+ * An error thrown when the encryption algorithm is unsupported
+ * @extends Error
  */
-class NotImplementedError extends Error {
+class UnsupportedAlgorithmError extends Error {
   /**
-   * @param  {String} message  An error message
-   * @param  {Object} metadata Contextual data to be included in the error
+   * @constructor
+   * @param {string} message
+   * @param {string} algorithm
    */
-  constructor(message, metadata) {
+  constructor(message, algorithm) {
     super(message);
     this.message = message;
-    this.name = 'NotImplementedError';
-    this.metadata = metadata || {};
+    this.name = 'UnsupportedAlgorithmError';
+    this.algorithm = algorithm;
   }
 }
 
-exports.NotImplementedError = NotImplementedError;
+exports.UnsupportedAlgorithmError = UnsupportedAlgorithmError;


### PR DESCRIPTION
This PR adds a check against starting Turnstile with a weak hashing algorithm. Because there is no relationship between the authorization scheme name and the actual hashing algorithm used to generate the signature it is possible to be in a state where, due to a misconfiguration, a weak hashing algorithm like MD4 could be used to generate the signature while a request could still contain the `Rapid7-HMAC-V1-SHA256` scheme in the `Authorization` header and pass the check against an invalid authorization header.

```
signature := Base64<HMAC-MD4<#(key-secret), #(challenge-body)>>
```

Currently `SHA256` and `SHA512` are supported but additional hashing algorithms can be added in the future.

Resolves #26.