### PR TITLE
Update documentation

### DIFF
--- a/docs/_pages/configuration.md
+++ b/docs/_pages/configuration.md
@@ -54,7 +54,7 @@ Paths may be absolute or relative to the process's working directory. The follow
     /*
      * Configure the HMAC signing algorithm and maximum date-header skew
      */
-    algorithm: 'sha256',
+    algorithm: 'SHA256',
     skew: 1000
   },
 

--- a/docs/_pages/signing-spec.md
+++ b/docs/_pages/signing-spec.md
@@ -105,11 +105,13 @@ Requests MUST include an [RFC 3230 Section 4.3.2] compliant Digest header:
 
     digest-header := ("Digest" ":" instance-digest)
     instance-digest := (algorithm "=" signature)
-    algorithm := "sha1" | "sha256" | "sha512"
+    algorithm := "SHA1" | "SHA256" | "SHA512"
 
-The Digest header's field-value  includes both the algorithm and the generated signature value. This allows the Client and Server to negotiate the algorithm used to generate the digest signature.
+The Digest header's field-value includes both the algorithm and the generated signature value. This allows the Client and Server to negotiate the algorithm used to generate the digest signature.
 
 Algorithms known to be easily manipulated MUST be banned by service implementations.
+
+The algorithm MUST be specified in UPPERCASE.
 
 The signature MUST include the `instance-digest` field.
 


### PR DESCRIPTION
This PR updates the documentation to note that the hashing algorithm in the instance digest *MUST* be specified in UPPERCASE and updates the example configuration accordingly.