### PR TITLE
Allow limiting the request body size

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -26,7 +26,12 @@ app.use((req, res, next) => {
   }
   next();
 });
-app.use(bodyParser.raw({type: '*/*'}));
+
+app.use(bodyParser.raw({
+  type: '*/*',
+  limit: Config.get('listen:limit')
+}));
+
 // Only attach the correlation ID middleware if it's enabled
 if (Config.get('correlation:enable')) {
   app.use(require('../lib/control/correlation').create(Config.get('correlation')));

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,8 @@ if (Config.get('config')) {
 Config.defaults({
   listen: {
     port: 9300,
-    bind: '0.0.0.0'
+    bind: '0.0.0.0',
+    limit: '10mb'
   },
   log: {
     level: 'info',
@@ -48,6 +49,7 @@ Config.defaults({
   },
   service: {
     port: 9301,
-    hostname: 'localhost'
+    hostname: 'localhost',
+    limit: '10mb'
   }
 });

--- a/lib/control/forward.js
+++ b/lib/control/forward.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const proxy = require('express-http-proxy');
+const bytes = require('bytes');
 
 /**
  * Proxy requests to an HTTP server
@@ -34,12 +35,13 @@ exports.create = function(options) {
   return proxy(`${context.hostname}:${context.port}`, {
     preserveHostHdr: true,
     parseReqBody: false,
-    limit: '10mb',
+    limit: Config.get('service:limit'),
     decorateRequest: (proxyReq, originalReq) => {
       Log.debug(`Forwarding request to ${context.hostname}:${context.port}${originalReq.url}`, {
         identifier: originalReq.identifier,
         method: originalReq.method,
-        path: originalReq.url
+        path: originalReq.url,
+        size: bytes(parseInt(originalReq.headers['content-length'], 10))
       });
     }
     // intercept: (rsp, data, req, res, callback) => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "body-parser": "^1.17.1",
+    "bytes": "^2.4.0",
     "express": "^4.15.2",
     "express-http-proxy": "^0.11.0",
     "nconf": "~0.8.4",


### PR DESCRIPTION
This PR adds a config option for limiting both the size of the request body for turnstile as well as the downstream service.