### PR TITLE
Feature: PropsdStore

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,10 @@ Config.defaults({
   local: {
     db: {
       path: 'data/keys.json',
-      signal: 'SIGHUP'
+      signal: 'SIGHUP',
+      propsd: false,
+      prefix: '',
+      delimiter: ''
     },
     algorithm: 'SHA256',
     skew: 1000

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,8 +44,7 @@ Config.defaults({
       path: 'data/keys.json',
       signal: 'SIGHUP',
       propsd: false,
-      prefix: '',
-      delimiter: ''
+      prefix: ''
     },
     algorithm: 'SHA256',
     skew: 1000

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -169,13 +169,13 @@ exports.authn = function(options) {
 
   db.on('error', (err) => Log.error(err));
 
-  Log.info(`Using local authentication controller with database ${db.path}`);
+  Log.info(`Using authentication controller with database ${db.path}`);
 
   // Return a request handler
   return function local(req, res, next) {
     const identifier = req.identifier;
 
-    Log.debug('Enforcing local token validator', {
+    Log.debug('Enforcing token validator', {
       identifier
     });
 
@@ -185,19 +185,22 @@ exports.authn = function(options) {
 
     const signature = new Signature(algorithm, req);
 
-    signature.sign(db.lookup(req));
-    Log.debug(`Request Signature: ${req.signature}`, {
-      identifier
-    });
-    Log.debug(`Challenge Signature: ${signature.signature}`, {
-      identifier
-    });
+    db.lookup(req).then((identity) => {
+      signature.sign(identity);
 
-    signature.verify(req.signature);
-    Log.debug('Authenticated. Forwarding request', {
-      identifier
-    });
+      Log.debug(`Request Signature: ${req.signature}`, {
+        identifier
+      });
+      Log.debug(`Challenge Signature: ${signature.signature}`, {
+        identifier
+      });
 
-    next();
+      signature.verify(req.signature);
+      Log.debug('Authenticated. Forwarding request', {
+        identifier
+      });
+
+      next();
+    });
   };
 };

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -11,6 +11,7 @@ const AUTHN_PROTOCOL = 'Rapid7-HMAC-V1-SHA256';
 
 const FileStore = require('./file_store');
 const RemoteStore = require('./remote_store');
+const PropsdStore = require('./propsd_store');
 
 /**
  * Factory function to determine the type of store to return.
@@ -22,6 +23,10 @@ const RemoteStore = require('./remote_store');
 const Store = exports.Store = (options) => {
   Log.debug('OPTIONS', options);
   const path = url.parse(options.path);
+
+  if (options.propsd) {
+    return new PropsdStore(options);
+  }
 
   if (path.hostname) {
     return new RemoteStore(options);

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -58,8 +58,7 @@ class PropsdStore extends Store {
 
           if (this.prefix) {
             // Only replace the prefix and delimiter if they exist
-            resultKey = key.replace(this.prefix, '')
-                .replace(this.delimiter, '');
+            resultKey = key.replace(this.prefix, '');
           }
 
           obj[resultKey] = data[key];

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const rp = require('request-promise-native');
+const assert = require('assert');
+
+const Store = require('./store');
+
+/**
+ * In-memory key database
+ * @module
+ */
+
+/**
+ * A Propsd endpoint-based key store
+ *
+ * @link http://github.com/rapid7/propsd
+ * @extends Store
+ */
+class PropsdStore extends Store {
+  /**
+   * @param  {Object} options
+   * @param  {String} options.signal  The OS signal upon which keys should be reloaded from disk
+   * @param  {String} options.path    The Propsd URL
+   * @param  {String} options.prefix  The key prefix Turnstile should use to identify keys
+   * @param  {String} options.delimiter The delimiter used to separate the prefix from the identity
+   */
+  constructor(options) {
+    super(options);
+
+    this.prefix = options.prefix;
+    this.path = options.path;
+    this.delimiter = options.delimiter;
+
+    this.load();
+  }
+
+  /**
+   * Load keys from a remote HTTP endpoint
+   */
+  load() {
+    rp({
+      uri: this.path,
+      json: true
+    }).then((data) => {
+      assert(typeof data === 'object');
+      // Keys are the result of filtering the Propsd property set by the prefix, then removing the prefix from the
+      // key leaving an object of `identity: secret`.
+      this.keys = Object.keys(data)
+        .filter((key) => key.startsWith(this.prefix))
+        .reduce((obj, key) => {
+          let resultKey = key;
+
+          if (this.prefix) {
+            // Only replace the prefix and delimiter if they exist
+            resultKey = key.replace(this.prefix, '').replace(this.delimiter, '');
+          }
+
+          obj[resultKey] = data[key];
+
+          return obj;
+        }, {});
+      this.emit('update');
+    }).catch((err) => {
+      this.emit('error', err);
+    });
+  }
+}
+
+module.exports = PropsdStore;

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -84,20 +84,15 @@ class PropsdStore extends Store {
     const identity = req.identity;
     const identifier = req.identifier;
 
-    return new Promise((resolve, reject) => {
-      if (this.keys.hasOwnProperty(identity)) {
-        resolve(this.keys[identity]);
+    // get keys from propsd only once and see if they exist, if not, reject
+    return this.load().then(() => {
+      if (!this.keys.hasOwnProperty(identity)) {
+        throw new Errors.AuthorizationError('Invalid authentication factors', {
+          identifier
+        });
       }
-      // get keys from propsd only once and see if they exist, if not, reject
-      this.load().then(() => {
-        if (!this.keys.hasOwnProperty(identity)) {
-          reject(new Errors.AuthorizationError('Invalid authentication factors', {
-            identifier
-          }));
-        }
 
-        resolve(this.keys[identity]);
-      });
+      return this.keys[identity];
     });
   }
 }

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -36,11 +36,21 @@ class PropsdStore extends Store {
   }
 
   /**
-   * Load keys from a remote HTTP endpoint
+   * Load keys from a Propsd endpoint
    *
-   * @return {Promise}
+   * This is a no-op because we hit Propsd every time we do a lookup
    */
   load() {
+    this.emit('update');
+  }
+
+  /**
+   * Query the Propsd endpoint
+   *
+   * @return {Promise<Object>}
+   * @private
+   */
+  _query() {
     return rp({
       uri: this.path,
       json: true
@@ -52,22 +62,19 @@ class PropsdStore extends Store {
       return data;
     }).then((data) => {
       return Object.keys(data)
-        .filter((key) => key.startsWith(this.prefix))
-        .reduce((obj, key) => {
-          let resultKey = key;
+          .filter((key) => key.startsWith(this.prefix))
+          .reduce((obj, key) => {
+            let resultKey = key;
 
-          if (this.prefix) {
-            // Only replace the prefix and delimiter if they exist
-            resultKey = key.replace(this.prefix, '');
-          }
+            if (this.prefix) {
+              // Only replace the prefix and delimiter if they exist
+              resultKey = key.replace(this.prefix, '');
+            }
 
-          obj[resultKey] = data[key];
+            obj[resultKey] = data[key];
 
-          return obj;
-        }, {});
-    }).then((keys) => {
-      this.keys = keys;
-      this.emit('update');
+            return obj;
+          }, {});
     }).catch((err) => {
       this.emit('error', err);
     });
@@ -85,14 +92,14 @@ class PropsdStore extends Store {
     const identifier = req.identifier;
 
     // get keys from propsd only once and see if they exist, if not, reject
-    return this.load().then(() => {
-      if (!this.keys.hasOwnProperty(identity)) {
+    return this._query().then((keys) => {
+      if (!keys.hasOwnProperty(identity)) {
         throw new Errors.AuthorizationError('Invalid authentication factors', {
           identifier
         });
       }
 
-      return this.keys[identity];
+      return keys[identity];
     });
   }
 }

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -38,27 +38,33 @@ class PropsdStore extends Store {
    * Load keys from a remote HTTP endpoint
    */
   load() {
-    rp({
+    return rp({
       uri: this.path,
       json: true
     }).then((data) => {
       assert(typeof data === 'object');
       // Keys are the result of filtering the Propsd property set by the prefix, then removing the prefix from the
       // key leaving an object of `identity: secret`.
-      this.keys = Object.keys(data)
+
+      return data;
+    }).then((data) => {
+      return Object.keys(data)
         .filter((key) => key.startsWith(this.prefix))
         .reduce((obj, key) => {
           let resultKey = key;
 
           if (this.prefix) {
             // Only replace the prefix and delimiter if they exist
-            resultKey = key.replace(this.prefix, '').replace(this.delimiter, '');
+            resultKey = key.replace(this.prefix, '')
+                .replace(this.delimiter, '');
           }
 
           obj[resultKey] = data[key];
 
           return obj;
         }, {});
+    }).then((keys) => {
+      this.keys = keys;
       this.emit('update');
     }).catch((err) => {
       this.emit('error', err);

--- a/lib/provider/local/propsd_store.js
+++ b/lib/provider/local/propsd_store.js
@@ -4,6 +4,7 @@ const rp = require('request-promise-native');
 const assert = require('assert');
 
 const Store = require('./store');
+const Errors = require('../../errors');
 
 /**
  * In-memory key database
@@ -36,6 +37,8 @@ class PropsdStore extends Store {
 
   /**
    * Load keys from a remote HTTP endpoint
+   *
+   * @return {Promise}
    */
   load() {
     return rp({
@@ -68,6 +71,34 @@ class PropsdStore extends Store {
       this.emit('update');
     }).catch((err) => {
       this.emit('error', err);
+    });
+  }
+
+  /**
+   * Look up a key's secret by key-id
+   *
+   * @param  {HTTP.IncomingMessage} req   The key-id to lookup
+   * @return {Promise<String|Errors.AuthorizationError>}  The key's secret or an error if the requested key-id is not
+   * defined
+   */
+  lookup(req) {
+    const identity = req.identity;
+    const identifier = req.identifier;
+
+    return new Promise((resolve, reject) => {
+      if (this.keys.hasOwnProperty(identity)) {
+        resolve(this.keys[identity]);
+      }
+      // get keys from propsd only once and see if they exist, if not, reject
+      this.load().then(() => {
+        if (!this.keys.hasOwnProperty(identity)) {
+          reject(new Errors.AuthorizationError('Invalid authentication factors', {
+            identifier
+          }));
+        }
+
+        resolve(this.keys[identity]);
+      });
     });
   }
 }

--- a/lib/provider/local/remote_store.js
+++ b/lib/provider/local/remote_store.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const rp = require('request-promise-native');
+const assert = require('assert');
 
 const Store = require('./store');
 
@@ -35,6 +36,8 @@ class RemoteStore extends Store {
       uri: this.path,
       json: true
     }).then((data) => {
+      assert(typeof data === 'object');
+
       this.keys = data;
       this.emit('update');
     }).catch((err) => {

--- a/lib/provider/local/store.js
+++ b/lib/provider/local/store.js
@@ -42,20 +42,22 @@ class Store extends EventEmitter {
    * Look up a key's secret by key-id
    *
    * @param  {HTTP.IncomingMessage} req   The key-id to lookup
-   * @return {String}                     The key's secret, if the key-id is defined
-   * @throws {Errors.AuthorizationError}  If the requested key-id is not defined
+   * @return {Promise<String|Errors.AuthorizationError>}  The key's secret or an error if the requested key-id is not
+   * defined
    */
   lookup(req) {
     const identity = req.identity;
     const identifier = req.identifier;
 
-    if (!this.keys.hasOwnProperty(identity)) {
-      throw new Errors.AuthorizationError('Invalid authentication factors', {
-        identifier
-      });
-    }
+    return new Promise((resolve, reject) => {
+      if (!this.keys.hasOwnProperty(identity)) {
+        reject(new Errors.AuthorizationError('Invalid authentication factors', {
+          identifier
+        }));
+      }
 
-    return this.keys[identity];
+      resolve(this.keys[identity]);
+    });
   }
 }
 

--- a/lib/provider/local/store.js
+++ b/lib/provider/local/store.js
@@ -24,6 +24,8 @@ class Store extends EventEmitter {
     }, options);
     super();
 
+    this.keys = {};
+
     this.options = options;
     this.signal = options.signal.toUpperCase();
 

--- a/test/10-store.js
+++ b/test/10-store.js
@@ -39,12 +39,15 @@ describe('lib/local/store', function storage() {
     const dbImpl = Local.Store(db);
 
     it('throws an error when `lookup` is called with an invalid key', function behavior() {
-      expect(() => dbImpl.lookup('bogus key')).to.throw(Errors.AuthorizationError);
+      return dbImpl.lookup('bogus key').catch((err) => {
+        expect(err).to.be.instanceof(Errors.AuthorizationError);
+      });
     });
 
     it('`lookup` returns a secret when it is called with a valid key', function behavior() {
-      expect(() => dbImpl.lookup(fixture)).to.not.throw();
-      expect(dbImpl.lookup(fixture)).to.equal(fixture.secret);
+      return dbImpl.lookup(fixture).then((key) => {
+        expect(key).to.equal(fixture.secret);
+      });
     });
   });
 });

--- a/test/11-local-file-store.js
+++ b/test/11-local-file-store.js
@@ -4,6 +4,7 @@ const Path = require('path');
 require('./resource/config');
 
 const Local = require('../lib/provider/local');
+const Resource = require('./resource');
 const expect = require('chai').expect;
 
 const db = {
@@ -12,6 +13,9 @@ const db = {
 };
 
 describe('lib/local/file_store', function storage() {
+  // Cleanup process event listeners
+  afterEach(Resource.cleanup);
+
   describe('Events', function events() {
     it('emits `update` after the data file is loaded', function behavior(done) {
       const store = Local.Store(db);

--- a/test/12-local-remote-store.js
+++ b/test/12-local-remote-store.js
@@ -2,7 +2,6 @@
 
 require('./resource/config');
 
-const Errors = require('../lib/errors');
 const Local = require('../lib/provider/local');
 const Resource = require('./resource');
 const expect = require('chai').expect;
@@ -28,17 +27,28 @@ describe('lib/local/remote_store', function storage() {
   nock('http://localhost:9100')
     .persist()
     .get('/v1/properties/turnstile.keys')
-    .reply(200, resp);
+    .reply(200, fixture)
+    .get('/v1/properties/malformed.keys')
+    .reply(200, 'not an object with identity:key');
 
   describe('Events', function events() {
-    it('emits `update` after the data file is loaded', function behavior(done) {
-      Local.Store(db).once('update', done);
+    it('emits `update` after the remote data is loaded', function behavior(done) {
+      Local.Store(db).once('update', () => done());
     });
 
-    it('emits `error` if a data file can not be loaded', function behavior(done) {
+    it('emits `error` if remote data can not be loaded', function behavior(done) {
       Local.Store({
         path: 'http://localhost:9100/v1/properties/not.keys'
       }).once('error', function error(err) {
+        expect(err).to.be.an.instanceOf(Error);
+        done();
+      });
+    });
+
+    it('emits `error` if remote data is malformed', function(done) {
+      Local.Store({
+        path: 'http://localhost:9100/v1/properties/malformed.keys'
+      }).once('error', (err) => {
         expect(err).to.be.an.instanceOf(Error);
         done();
       });

--- a/test/12-local-remote-store.js
+++ b/test/12-local-remote-store.js
@@ -4,6 +4,7 @@ require('./resource/config');
 
 const Errors = require('../lib/errors');
 const Local = require('../lib/provider/local');
+const Resource = require('./resource');
 const expect = require('chai').expect;
 const nock = require('nock');
 
@@ -21,6 +22,9 @@ const resp = {};
 resp[key] = secret;
 
 describe('lib/local/remote_store', function storage() {
+  // Cleanup process event listeners
+  afterEach(Resource.cleanup);
+
   nock('http://localhost:9100')
     .persist()
     .get('/v1/properties/turnstile.keys')

--- a/test/14-local-propsd-store.js
+++ b/test/14-local-propsd-store.js
@@ -1,0 +1,101 @@
+'use strict';
+
+require('./resource/config');
+
+const Local = require('../lib/provider/local');
+const expect = require('chai').expect;
+const nock = require('nock');
+const Resource = require('./resource');
+
+const secret = '6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq';
+
+const fixture = {
+  'some-service-in-us-east-1': secret,
+  'some-service-in-us-west-1': secret
+};
+
+const prefixedFixture = {
+  'prefix.some-service-in-us-east-1': secret,
+  'prefix.some-service-in-us-west-1': secret
+};
+
+describe('lib/local/propsd_store', function storage() {
+  // Cleanup process event listeners
+  afterEach(Resource.cleanup);
+
+  nock('http://localhost:9100')
+    .persist()
+    .get('/v1/properties')
+    .reply(200, fixture)
+    .get('/v1/properties/prefixed')
+    .reply(200, prefixedFixture)
+    .get('/v1/properties/malformed')
+    .reply(200, 'this is a malformed property');
+
+  describe('Events', function events() {
+    it('emits `update` after the keys are loaded from Propsd', function behavior(done) {
+      Local.Store({
+        path: 'http://localhost:9100/v1/properties',
+        signal: 'SIGHUP',
+        propsd: true,
+        prefix: '',
+        delimiter: ''
+      })
+          .once('update', done);
+    });
+
+    it('emits `error` if keys can not be loaded', function behavior(done) {
+      Local.Store({
+        path: 'http://localhost:9100/v1/properties/not.keys',
+        propsd: true,
+        prefix: '',
+        delimiter: ''
+      }).once('error', function error(err) {
+        expect(err).to.be.an.instanceOf(Error);
+        done();
+      });
+    });
+  });
+
+  describe('Keys', function() {
+    it('parses keys correctly from a Propsd endpoint', function(done) {
+      const propsd = Local.Store({
+        path: 'http://localhost:9100/v1/properties',
+        propsd: true,
+        prefix: '',
+        delimiter: ''
+      });
+
+      propsd.once('update', () => {
+        expect(propsd.keys).to.eql(fixture);
+        done();
+      });
+    });
+
+    it('emits `error` if Propsd data is malformed', function(done) {
+      Local.Store({
+        path: 'http://localhost:9100/v1/properties/malformed',
+        propsd: true,
+        prefix: '',
+        delimiter: ''
+      }).once('error', (err) => {
+        expect(err).to.be.an.instanceOf(Error);
+        done();
+      });
+    });
+
+    it('removes a key prefix if one is defined', function(done) {
+      const propsd = Local.Store({
+        path: 'http://localhost:9100/v1/properties/prefixed',
+        propsd: true,
+        prefix: 'prefix',
+        delimiter: '.'
+      });
+
+      propsd.once('update', () => {
+        expect(propsd.keys).to.eql(fixture);
+        done();
+      });
+    });
+  });
+});

--- a/test/14-local-propsd-store.js
+++ b/test/14-local-propsd-store.js
@@ -78,8 +78,7 @@ describe('lib/local/propsd_store', function storage() {
     it('removes a key prefix if one is defined', function(done) {
       const propsd = Local.Store(Object.assign({}, defaultPropsdOpts, {
         path: 'http://localhost:9100/v1/properties/prefixed',
-        prefix: 'prefix',
-        delimiter: '.'
+        prefix: 'prefix.'
       }));
 
       propsd.once('update', () => {

--- a/test/14-local-propsd-store.js
+++ b/test/14-local-propsd-store.js
@@ -88,43 +88,31 @@ describe('lib/local/propsd_store', function storage() {
     });
 
     describe('Lookup', function() {
-      it('checks for new keys if a client tries to authorize with a key it doesn\'t recognize', function(done) {
-        const scope = nock('http://localhost:9200')
-          .get('/v1/properties')
-          .reply(200, fixture)
-          .get('/v1/properties')
-          .reply(200, Object.assign({}, fixture, {
-            'some-other-service-in-us-east-1': secret
-          }));
+      const scope = nock('http://localhost:9200')
+        .persist()
+        .get('/v2/properties')
+        .reply(200, fixture);
 
-        const propsd = Local.Store(Object.assign({}, defaultPropsdOpts, {
-          path: 'http://localhost:9200/v1/properties'
-        }));
-
-        propsd.once('update', () => {
-          propsd.lookup({identity: 'some-other-service-in-us-east-1', identifier: 'some-uuid'}).then((key) => {
-            expect(scope.isDone()).to.be.true;
-            done();
-          }).catch(done);
-        });
-      });
-
-      it('emits `error` if a client tries to authorize with a key it doesn\'t recognize and that key isn\'t available' +
-      ' in prosd', function(done) {
-        const scope = nock('http://localhost:9200')
-          .get('/v2/properties')
-          .reply(200, fixture)
-          .get('/v2/properties')
-          .reply(200, fixture);
-
+      it('returns a key on lookup if that key is available in Propsd', function() {
         const propsd = Local.Store(Object.assign({}, defaultPropsdOpts, {
           path: 'http://localhost:9200/v2/properties'
         }));
 
         propsd.once('update', () => {
-          propsd.lookup({identity: 'some-other-service-in-us-east-1', identifier: 'some-uuid'}).catch((err) => {
+          return propsd.lookup({identity: 'some-service-in-us-east-1', identifier: 'some-uuid'}).then((keys) => {
+            expect(keys).to.equal(fixture['some-service-in-us-east-1']);
+          });
+        });
+      });
+
+      it('emits `error` if a client tries to authorize with a key that isn\'t available in Prosd', function() {
+        const propsd = Local.Store(Object.assign({}, defaultPropsdOpts, {
+          path: 'http://localhost:9200/v2/properties'
+        }));
+
+        propsd.once('update', () => {
+          return propsd.lookup({identity: 'some-other-service-in-us-east-1', identifier: 'some-uuid'}).catch((err) => {
             expect(err).to.be.instanceof(Errors.AuthorizationError);
-            done();
           });
         });
       });

--- a/test/14-local-propsd-store.js
+++ b/test/14-local-propsd-store.js
@@ -19,6 +19,14 @@ const prefixedFixture = {
   'prefix.some-service-in-us-west-1': secret
 };
 
+const defaultPropsdOpts = {
+  path: 'http://localhost:9100/v1/properties',
+  signal: 'SIGHUP',
+  propsd: true,
+  prefix: '',
+  delimiter: ''
+};
+
 describe('lib/local/propsd_store', function storage() {
   // Cleanup process event listeners
   afterEach(Resource.cleanup);
@@ -34,23 +42,13 @@ describe('lib/local/propsd_store', function storage() {
 
   describe('Events', function events() {
     it('emits `update` after the keys are loaded from Propsd', function behavior(done) {
-      Local.Store({
-        path: 'http://localhost:9100/v1/properties',
-        signal: 'SIGHUP',
-        propsd: true,
-        prefix: '',
-        delimiter: ''
-      })
-          .once('update', done);
+      Local.Store(defaultPropsdOpts).once('update', done);
     });
 
     it('emits `error` if keys can not be loaded', function behavior(done) {
-      Local.Store({
-        path: 'http://localhost:9100/v1/properties/not.keys',
-        propsd: true,
-        prefix: '',
-        delimiter: ''
-      }).once('error', function error(err) {
+      Local.Store(Object.assign({}, defaultPropsdOpts, {
+        path: 'http://localhost:9100/v1/properties/not.keys'
+      })).once('error', function error(err) {
         expect(err).to.be.an.instanceOf(Error);
         done();
       });
@@ -59,12 +57,7 @@ describe('lib/local/propsd_store', function storage() {
 
   describe('Keys', function() {
     it('parses keys correctly from a Propsd endpoint', function(done) {
-      const propsd = Local.Store({
-        path: 'http://localhost:9100/v1/properties',
-        propsd: true,
-        prefix: '',
-        delimiter: ''
-      });
+      const propsd = Local.Store(defaultPropsdOpts);
 
       propsd.once('update', () => {
         expect(propsd.keys).to.eql(fixture);
@@ -73,24 +66,20 @@ describe('lib/local/propsd_store', function storage() {
     });
 
     it('emits `error` if Propsd data is malformed', function(done) {
-      Local.Store({
-        path: 'http://localhost:9100/v1/properties/malformed',
-        propsd: true,
-        prefix: '',
-        delimiter: ''
-      }).once('error', (err) => {
+      Local.Store(Object.assign({}, defaultPropsdOpts, {
+        path: 'http://localhost:9100/v1/properties/malformed'
+        })).once('error', (err) => {
         expect(err).to.be.an.instanceOf(Error);
         done();
       });
     });
 
     it('removes a key prefix if one is defined', function(done) {
-      const propsd = Local.Store({
+      const propsd = Local.Store(Object.assign({}, defaultPropsdOpts, {
         path: 'http://localhost:9100/v1/properties/prefixed',
-        propsd: true,
         prefix: 'prefix',
         delimiter: '.'
-      });
+      }));
 
       propsd.once('update', () => {
         expect(propsd.keys).to.eql(fixture);

--- a/test/resource/config.js
+++ b/test/resource/config.js
@@ -13,7 +13,10 @@ Config.defaults({
   local: {
     db: {
       path: Path.join(__dirname, '/keys.json'),
-      signal: 'SIGHUP'
+      signal: 'SIGHUP',
+      propsd: false,
+      prefix: '',
+      delimiter: ''
     },
     algorithm: 'SHA256',
     skew: 5000

--- a/test/resource/index.js
+++ b/test/resource/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Clean up process event listeners
+ */
+exports.cleanup = () => {
+  process.removeAllListeners('SIGHUP');
+};


### PR DESCRIPTION
This PR adds a `Store` for [Propsd](http://github.com/rapid7/propsd). The store makes an HTTP request to the Propsd endpoint specified in the config file, looks for keys with a given prefix, then assembles an object of `identity: secret` which it sets as keys. Requests to Turnstile are then validated against that set of keys.

cc: @aguerlain-r7.