### PR TITLE
Removed dependency on node-libuuid and the libuuid C bindings.

### DIFF
--- a/lib/control/correlation.js
+++ b/lib/control/correlation.js
@@ -1,5 +1,5 @@
 'use strict';
-const UUID = require('node-libuuid');
+const UUID = require('uuid');
 
 /**
  * Read or generate a correlation identifier for logging and debugging

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "express": "^4.15.2",
     "express-http-proxy": "^0.11.0",
     "nconf": "~0.8.4",
-    "node-libuuid": "~2.0.0",
     "request": "^2.80.0",
     "request-promise-native": "^1.0.3",
+    "uuid": "^3.0.1",
     "winston": "~2.2.0"
   }
 }


### PR DESCRIPTION
This PR removes the `node-libuuid` package in favor of using one that doesn't require `libuuid` C bindings.