### PR TITLE
Feature: Multiple keys per identity

### DIFF
--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -183,24 +183,54 @@ exports.authn = function(options) {
     digest(algorithm, req);
     authorization(req);
 
-    const signature = new Signature(algorithm, req);
-
     db.lookup(req).then((identity) => {
-      signature.sign(identity);
+      // Make sure we're working with an array
+      if (typeof identity === 'string') {
+        identity = [identity];
+      }
 
-      Log.debug(`Request Signature: ${req.signature}`, {
-        identifier
-      });
-      Log.debug(`Challenge Signature: ${signature.signature}`, {
-        identifier
-      });
-
-      signature.verify(req.signature);
-      Log.debug('Authenticated. Forwarding request', {
+      // We can prep this generic AuthorizationError to throw in case we don't
+      // end up with a valid signature and for some reason `signature.verify`
+      // doesn't throw.
+      let error = new Errors.AuthorizationError('Invalid authentication factors', {
         identifier
       });
 
-      next();
+      const valid = identity.some((id) => {
+        const signature = new Signature(algorithm, req);
+
+        signature.sign(id);
+
+        Log.debug(`Request Signature: ${req.signature}`, {
+          identifier
+        });
+        Log.debug(`Challenge Signature: ${signature.signature}`, {
+          identifier
+        });
+
+        try {
+          signature.verify(req.signature);
+        } catch (err) {
+          error = err;
+
+          return false;
+        }
+
+        Log.debug('Authenticated. Forwarding request', {
+          identifier
+        });
+
+        // If we haven't thrown (the key is valid) we return true
+        // and Array.some will consider its job fulfilled and won't
+        // continue iterating.
+        return true;
+      });
+
+      if (valid) {
+        return next();
+      }
+
+      throw error;
     }).catch((err) => {
       next(err);
     });

--- a/test/resource/http.js
+++ b/test/resource/http.js
@@ -1,17 +1,4 @@
 'use strict';
-/**
- * This check fails for assignment of values on an Object argument, and does not
- * allow for argument type-checking/default setters. */
-/* eslint-disable no-param-reassign */
-
-/**
- * This check is invalid. Functions defined outside of a class are still hoisted. */
-/* eslint-disable no-use-before-define */
-
-const Crypto = require('crypto');
-const EventEmitter = require('events').EventEmitter;
-const HTTP = require('http');
-const expect = require('chai').expect;
 
 /**
  * Testing stubs for HTTP.IncomingMessage and HTTP.ServerResponse
@@ -75,78 +62,6 @@ class ServerResponse extends require('stream').PassThrough {
   }
 }
 exports.ServerResponse = ServerResponse;
-
-/**
- * Stub server for client testing
- *
- * @param {Function}  ready
- * @return {HTTP.Server}
- */
-exports.server = function() {
-  const server = HTTP.createServer(function handler(req, res) {
-    const chunks = [];
-
-    req.on('data', (chunk) => chunks.push(chunk));
-    req.on('end', (chunk) => {
-      if (chunk) { chunks.push(chunk); }
-      req.body = Buffer.concat(chunks).toString('utf8');
-
-      if (handlers.hasOwnProperty(req.url)) {
-        return handlers[req.url](req, res);
-      }
-
-      const body = 'Not Found';
-
-      res.writeHead(404, {
-        'content-type': 'text/plain',
-        'content-length': Buffer.byteLength(body, 'utf8')
-      });
-
-      res.write(body, 'utf8');
-      res.end();
-    });
-  });
-
-  const handlers = server.handlers = {};
-
-  server.handle = function(handler) {
-    const path = '/' + Crypto.randomBytes(32).toString('hex');
-
-    if (handler instanceof Function) {
-      handlers[path] = handler;
-    } else if (handler instanceof Object) {
-      // Treat `handler` as a Fixture
-      handlers[path] = function _handler(req, res) {
-        expect(req.method).to.equal(handler.REQUEST.method);
-        expect(req.url).to.equal(path);
-        expect(req.headers).to.contain.keys({'content-type': handler.REQUEST.type});
-        expect(req.headers).to.contain.keys('content-length');
-        expect(req.body).to.equal(handler.REQUEST.body);
-
-        if (handler.RESPONSE.body) {
-          res.setHeader('content-length', Buffer.byteLength(handler.RESPONSE.body, 'utf8'));
-        }
-
-        res.setHeader('content-type', handler.RESPONSE.type);
-        res.writeHead(handler.RESPONSE.code);
-
-        if (handler.RESPONSE.body) {
-          res.write(handler.RESPONSE.body, 'utf8');
-        }
-
-        res.end();
-      };
-    }
-
-    return path;
-  };
-
-  server.start = function(ready) {
-    server.listen(0, '127.0.0.1', () => ready(server.address().port));
-  };
-
-  return server;
-};
 
 exports.bench = function(request, handler) {
   return new Promise((resolve, reject) => {

--- a/test/resource/keys.json
+++ b/test/resource/keys.json
@@ -1,3 +1,5 @@
 {
-  "7bf9708aa51b7f7859d0e68b6b62b8ab": "6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq"
+  "7bf9708aa51b7f7859d0e68b6b62b8ab": "6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq",
+  "some-turnstile-client": ["a-key-that-is-not-used",
+    "6jzQ+NyqY7PwOFpipttvbp53baOI/bqGdn4DMc2ALN2v3+rcNYWz/T4r+jORJHBq"]
 }


### PR DESCRIPTION
This PR adds the ability to load multiple keys for a given identity. This feature is optional (`String`s are coerced to `Array`s under the covers) but allows new keys to be introduced before old ones are revoked.