### PR TITLE
Fix date header parsing

### DIFF
--- a/bin/turnt
+++ b/bin/turnt
@@ -109,21 +109,17 @@ const conf = {
   secret: Config.get('secret')
 };
 
-const date = new Date();
 const url = Config.get('_')[0];
 const params = URL.parse(url);
 
+params.date = new Date();
 params.method = Config.get('method');
 params.identifier = 'turnt-request';
 params.headers = {
-  date: date.toUTCString(),
+  date: params.date.getTime(),
   host: params.host,
   'user-agent': `node-${process.version}/turnstile-tester`
 };
-
-// Round date to the nearest seconds for signing
-params.date = new Date(date);
-params.date.setMilliseconds(0);
 
 params.identity = Config.get('identity');
 

--- a/docs/_pages/signing-spec.md
+++ b/docs/_pages/signing-spec.md
@@ -83,7 +83,7 @@ The Host header is required for all HTTP/1.1 requests. It MAY be used by load ba
 
 A signature MUST have a bounded validity window on the order of minutes. The exact skew limit MAY vary depending upon how closely Clients' and Servers' clocks can be synchronized. Clients MUST include a date header with second precision as defined by [RFC 2616] Section 3.3.1:
 
-  HTTP-date := rfc1123-date | rfc850-date | asctime-date
+    HTTP-date := rfc1123-date | rfc850-date | asctime-date
 
 The signature MUST be bound to a canonical representation of the exact date encoded in the signed request's Date header. To ensure consistency across languages and platforms, this MUST be an ASCII encoded UNIX epoch timestamp, to millisecond precision:
 

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const url = require('url');
 const Crypto = require('crypto');
-const deprecate = require('depd')('turnstile.provider.local');
 
 const Errors = require('../../errors');
 const Signature = require('../../signature');
@@ -73,8 +72,10 @@ exports.validate = function(skew, request) {
       });
     }
   } else {
-    deprecate('Parsing date strings has been deprecated and will be removed in a later version. Instead use' +
-        ' millisecond-precision epoch time.');
+    Log.warn('Date string deprecation notice: use millisecond-precision epoch time instead', {
+      identifier: request.identifier,
+      ip: request.headers['x-forwarded-for'] || request.connection.remoteAddress
+    });
   }
   request.date = date;
 

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -62,16 +62,31 @@ exports.validate = function(skew, request) {
   });
 
   // Validate Date header
+  /** Because the spec was formatted in such a way as to make the date header
+   * section ambiguous, we are allowing some leniency in how dates are formatted.
+   *
+   * We will attempt to parse datetime strings first in keeping backwards
+   * compatibility. If that fails, we attempt to parse as if the header was
+   * a string representation of an integer. If that fails, we consider the
+   * header to be invalid.
+   */
   let date = new Date(request.headers.date);
 
+  // Passing an invalid date string to the Date constructor results in a
+  // Date object equal to NaN.
   if (isNaN(date)) {
+    // If the date string is invalid, we assume it's the number of milliseconds
+    // since the epoch and attempt to parse it as such.
     date = new Date(parseInt(request.headers.date, 10));
+    // If it's still not a valid date object then we throw an error.
     if (isNaN(date)) {
       throw new Errors.RequestError('Invalid Date header', {
         identifier: request.identifier
       });
     }
   } else {
+    // In cases where we find a valid datetime string we want to log that our
+    // date object was created this way with information to identify the client.
     Log.warn('Date string deprecation notice: use millisecond-precision epoch time instead', {
       identifier: request.identifier,
       ip: request.headers['x-forwarded-for'] || request.connection.remoteAddress

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const url = require('url');
 const Crypto = require('crypto');
+const deprecate = require('depd')('turnstile.provider.local');
 
 const Errors = require('../../errors');
 const Signature = require('../../signature');
@@ -62,17 +63,20 @@ exports.validate = function(skew, request) {
   });
 
   // Validate Date header
-  if (isNaN(request.headers.date)) {
-    throw new Errors.RequestError('Invalid Date header', {
-      identifier: request.identifier
-    });
+  let date = new Date(request.headers.date);
+
+  if (isNaN(date)) {
+    date = new Date(parseInt(request.headers.date, 10));
+    if (isNaN(date)) {
+      throw new Errors.RequestError('Invalid Date header', {
+        identifier: request.identifier
+      });
+    }
+  } else {
+    deprecate('Parsing date strings has been deprecated and will be removed in a later version. Instead use' +
+        ' millisecond-precision epoch time.');
   }
-  request.date = new Date(parseInt(request.headers.date, 10));
-  if (isNaN(request.date)) {
-    throw new Errors.RequestError('Invalid Date header', {
-      identifier: request.identifier
-    });
-  }
+  request.date = date;
 
   // Verify that the request date is close to $NOW
   const now = Date.now();

--- a/lib/provider/local/index.js
+++ b/lib/provider/local/index.js
@@ -62,7 +62,12 @@ exports.validate = function(skew, request) {
   });
 
   // Validate Date header
-  request.date = new Date(request.headers.date);
+  if (isNaN(request.headers.date)) {
+    throw new Errors.RequestError('Invalid Date header', {
+      identifier: request.identifier
+    });
+  }
+  request.date = new Date(parseInt(request.headers.date, 10));
   if (isNaN(request.date)) {
     throw new Errors.RequestError('Invalid Date header', {
       identifier: request.identifier

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "body-parser": "~1.17.1",
     "bytes": "~2.5.0",
     "conditional": "~5.3.0",
-    "depd": "^1.1.0",
     "express": "~4.15.2",
     "express-http-proxy": "~0.11.0",
     "hot-shots": "~4.4.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "body-parser": "~1.17.1",
     "bytes": "~2.5.0",
     "conditional": "~5.3.0",
+    "depd": "^1.1.0",
     "express": "~4.15.2",
     "express-http-proxy": "~0.11.0",
     "hot-shots": "~4.4.0",

--- a/test/13-local-auth.js
+++ b/test/13-local-auth.js
@@ -31,7 +31,8 @@ const fixture = {
     host: 'localhost',
     date: date.getTime(),
     digest: `${algorithm}=${signature}`,
-    authorization: `Rapid7-HMAC-V1-SHA256 ${authorization}`
+    authorization: `Rapid7-HMAC-V1-SHA256 ${authorization}`,
+    'x-forwarded-for': '127.0.0.1'
   },
   body
 };
@@ -90,16 +91,11 @@ describe('lib/provider/local', function() {
       });
     });
 
-    it('passes but emits a deprecation notice if the date header is a datetime string', function() {
+    it('passes if the date header is a datetime string', function() {
       const stringDate = Object.assign({}, fixture, {
         headers: Object.assign({}, fixture.headers, {
           date: (new Date()).toISOString()
         })
-      });
-
-      process.once('deprecation', (err) => {
-        expect(err.message).to.equal('Parsing date strings has been deprecated and will be removed in a later' +
-            ' version. Instead use millisecond-precision epoch time.');
       });
 
       return HTTP.bench(stringDate, (req, res) => validateWrapper(req, res)).then((data) => {

--- a/test/13-local-auth.js
+++ b/test/13-local-auth.js
@@ -29,7 +29,7 @@ const fixture = {
   date: new Date('Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)'),
   headers: {
     host: 'localhost',
-    date: 'Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)',
+    date: new Date('Thu Mar 24 2016 00:17:57 GMT-0400 (EDT)').getTime(),
     digest: `${algorithm}=${signature}`,
     authorization: `Rapid7-HMAC-V1-SHA256 ${authorization}`
   },
@@ -158,7 +158,7 @@ describe('lib/provider/local', function() {
     it('passes if headers are valid', function() {
       const valid = Object.assign({}, fixture, {
         headers: Object.assign({}, fixture.headers, {
-          date: (new Date()).toString()
+          date: (new Date()).getTime()
         })
       });
 
@@ -172,7 +172,7 @@ describe('lib/provider/local', function() {
     const generateRequest = (identity, secret) => {
       // Set the date key in headers and request. This is required to generate
       // a valid request signature for testing.
-      const date = (new Date()).toString();
+      const date = (new Date()).getTime();
       const req = Object.assign({}, fixture, {
         headers: Object.assign({}, fixture.headers, {date}),
         identity,


### PR DESCRIPTION
This PR resolves some confusion around how dates are supposed to be used. The signing spec states the following:

> A signature MUST have a bounded validity window on the order of minutes. The exact skew limit MAY vary depending upon how closely Clients' and Servers' clocks can be synchronized. Clients MUST include a date header with second precision as defined by [RFC 2616] Section 3.3.1:

>    HTTP-date := rfc1123-date | rfc850-date | asctime-date
 		 
> The signature MUST be bound to a canonical representation of the exact date encoded in the signed request's Date header. To ensure consistency across languages and platforms, this MUST be an ASCII encoded UNIX epoch timestamp, to millisecond precision:		 The signature MUST be bound to a canonical representation of the exact date encoded in the signed request's Date header. To ensure consistency across languages and platforms, this MUST be an ASCII encoded UNIX epoch timestamp, to millisecond precision:
 		 
>     date-header := UNIX_Epoch_Seconds<HTTP-date> * 1000

Therefore, all dates used, both to sign the request as well as send in the date header, should be time since the epoch expressed in milliseconds.