### PR TITLE
Cookbook: Specify package version

### DIFF
--- a/cookbook/recipes/_install_github_release.rb
+++ b/cookbook/recipes/_install_github_release.rb
@@ -20,4 +20,5 @@ end
 package 'turnstile' do
   source resources('remote_file[turnstile]').path
   provider Chef::Provider::Package::Dpkg
+  version node['turnstile']['version']
 end


### PR DESCRIPTION
This PR specifies the package version to install.

It resolves a subtle issue in the upgrade behavior of the `package` resource. Even though the default action of the `dpkg_package` resource calls `dpkg -i` (which doesn't have an upgrade mechanism), the logic around determining whether the `package` resource should actually call the `dpkg_resource` to upgrade checks whether the cached version is the same as the version to be installed.