### PR TITLE
Cookbook: fix node cookbook dependency

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -16,3 +16,4 @@ long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
 depends 'nodejs'
+depends 'ark', '~> 3.0.0'


### PR DESCRIPTION
This PR pins the version of ark cookbook that the nodejs cookbook depends on to the 3.0.x line as support for chef 12.5 has been deprecated in 3.1.