### PR TITLE
Make compatible with Ubuntu 18.04 and systemd 

### DIFF
--- a/cookbook/templates/default/systemd.service.erb
+++ b/cookbook/templates/default/systemd.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=<%= @description %>
+
+[Service]
+ExecStart=<%= ([@executable] + @flags).join(' ') %>
+<% unless @user.nil? %>User=<%= @user %><% end %>
+<% unless @group.nil? %>Group=<%= @group %><% end %>
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding conditional logic to allow installing on Ubuntu 14.04 (upstart) or Ubuntu 16.04 / 18.04 (systemd).
This has been done in a similar way to the tokend and propsd cookbooks. 